### PR TITLE
(chore) reorganise Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,64 +6,51 @@ ruby '2.5.1'
 
 gem 'rails', '5.2.1'
 
-gem 'pg'
-
-gem 'puma'
-
-# Gems used in all environments
-gem 'haml'
-gem 'haml-rails'
-gem 'jquery-rails'
-gem 'redcarpet' # Markdown
-
+gem 'actionpack-action_caching' # to support pre rails-4 style action caching
+gem 'bootsnap'
+gem 'coffee-rails'
+gem 'dalli'
 gem 'geocoder'
 gem 'gmaps4rails', '2.0.0.pre'
-
-# Caching
-gem 'actionpack-action_caching' # to support pre rails-4 style action caching
-gem 'dalli'
+gem 'haml-rails'
+gem 'jquery-rails'
 gem 'memcachier'
-gem 'rails-observers' # to support pre rails-4 style cache sweeping
-
+gem 'pg'
+gem 'puma'
 gem 'rack-attack'
-
-gem 'test-unit'
-
-gem 'coffee-rails'
+gem 'rails-observers' # to support pre rails-4 style cache sweeping
+gem 'redcarpet' # Markdown
+gem 'rollbar'
 gem 'sassc-rails'
+gem 'test-unit'
 gem 'uglifier'
-
-gem 'bootsnap'
 
 group :development do
   gem 'bullet'
   gem 'listen'
+  gem 'rack-mini-profiler', require: false
 end
 
 group :development, :test do
-  gem 'awesome_print'
-  gem 'binding_of_caller'
   gem 'dotenv-rails'
   gem 'factory_bot_rails'
   gem 'ffaker'
-  gem 'fuubar'
-  gem 'launchy'
   gem 'pry-rails'
-  gem 'rack-mini-profiler', require: false
   gem 'rb-fsevent'
   gem 'rspec-rails'
-  gem 'rubocop-rspec'
-  gem 'simplecov'
+  gem 'rubocop-rspec', require: false
 end
 
 group :test do
   gem 'capybara'
+  gem 'fuubar'
+  gem 'launchy'
   gem 'rails-controller-testing' # TODO: refactor tests so that we don't need this
   gem 'selenium-webdriver'
+  gem 'simplecov', require: false
   gem 'timecop'
 end
 
-gem 'rollbar'
 group :production do
   gem 'oj' # For Rollbar
   gem 'rack-canonical-host'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,9 +48,6 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
     ast (2.4.0)
-    awesome_print (1.8.0)
-    binding_of_caller (0.8.0)
-      debug_inspector (>= 0.0.1)
     bootsnap (1.3.2)
       msgpack (~> 1.0)
     builder (3.2.3)
@@ -77,7 +74,6 @@ GEM
     concurrent-ruby (1.0.5)
     crass (1.0.4)
     dalli (2.7.8)
-    debug_inspector (0.0.3)
     diff-lcs (1.3)
     docile (1.3.1)
     dotenv (2.5.0)
@@ -296,8 +292,6 @@ PLATFORMS
 
 DEPENDENCIES
   actionpack-action_caching
-  awesome_print
-  binding_of_caller
   bootsnap
   bullet
   capybara
@@ -309,7 +303,6 @@ DEPENDENCIES
   fuubar
   geocoder
   gmaps4rails (= 2.0.0.pre)
-  haml
   haml-rails
   jquery-rails
   launchy


### PR DESCRIPTION
- Alphabetise gems in a single block
- Move testing-only gems out of the dev/test block
- Move development-only gems out of the dev/test block
- Add "require false" to some gems which recommend that
- Remove binding_of_caller - it was an extension for better_errors
- Remove awesome-print - I don't use this