### PR TITLE
Use a realistic auth hash in development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,5 +8,9 @@ FACEBOOK_SECRET=
 
 # Comma-separated list of Facebook IDs of admin users
 # Can be found with e.g. https://findmyfbid.in/
-# 1234 is the user id for Omniauth in test mode
-ADMIN_USER_IDS=1234
+ADMIN_USER_IDS=89657934506423024 # random
+
+# User id to login with in development (we skip OAuth in development)
+# Defaults to a random 17-digit number
+# This should match ADMIN_USER_IDS if you want to be able to log in
+DEVELOPMENT_USER_LOGIN_ID=89657934506423024 # random

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,7 @@ Security/YAMLLoad:
 
 Style/NumericLiterals:
   Exclude:
+    - lib/omniauth_test_response_builder.rb
     # Files where this picks up a lot of false positives
     - spec/**/*_spec.rb
     - spec/support/**/*.rb
@@ -81,3 +82,4 @@ RSpec/ExampleLength:
   Exclude:
     - spec/system/**/*_spec.rb
     - spec/models/auth_response_spec.rb
+    - spec/lib/omniauth_test_response_builder_spec.rb

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -4,4 +4,9 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   provider :facebook, ENV['FACEBOOK_APP_ID'], ENV['FACEBOOK_SECRET'], scope: ''
 end
 
-OmniAuth.config.test_mode = true if Rails.env.development?
+if Rails.env.development?
+  require 'omniauth_test_response_builder'
+  OmniAuth.config.test_mode = true
+  login_user_id = ENV.fetch('DEVELOPMENT_USER_LOGIN_ID', Faker::Number.number(17))
+  OmniauthTestResponseBuilder.new.stub_auth_hash(id: login_user_id)
+end

--- a/lib/omniauth_test_response_builder.rb
+++ b/lib/omniauth_test_response_builder.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'faker'
+
+class OmniauthTestResponseBuilder
+  def initialize(hash_builder: OmniAuth::AuthHash, mock_auth_config: OmniAuth.config.mock_auth)
+    @hash_builder = hash_builder
+    @mock_auth_config = mock_auth_config
+  end
+
+  def stub_auth_hash(
+    id: Faker::Number.number(17),
+    name: Faker::Name.name,
+    token: SecureRandom.hex
+  )
+    raise "Can't stub authentication in production" if Rails.env.production?
+
+    auth_hash = facebook_auth_hash(id: id, name: name, token: token)
+    mock_auth_config[:facebook] = auth_hash
+  end
+
+  private
+
+  attr_reader :hash_builder, :mock_auth_config
+
+  def facebook_auth_hash(id:, name:, token:)
+    hash_builder.new(
+      'provider' => 'facebook',
+      'uid' => id,
+      'info' => {
+        'name' => name,
+        'image' => "http://graph.facebook.com/v2.10/#{id}/picture"
+      },
+      'credentials' => {
+        'token' => token,
+        'expires_at' => 1546086985,
+        'expires' => true
+      },
+      'extra' => {
+        'raw_info' => {
+          'name' => name,
+          'id' => id
+        }
+      }
+    )
+  end
+end

--- a/spec/lib/omniauth_test_response_builder_spec.rb
+++ b/spec/lib/omniauth_test_response_builder_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'lib/omniauth_test_response_builder'
+
+RSpec.describe OmniauthTestResponseBuilder do
+  describe '#stub_auth_hash' do
+    it 'configures Omniauth to return a fixed hash from all requests' do
+      auth_hash = instance_double('OmniAuth::AuthHash')
+      hash_builder = class_double('OmniAuth::AuthHash', new: auth_hash)
+      mock_auth_config = {}
+
+      described_class.new(hash_builder: hash_builder, mock_auth_config: mock_auth_config).stub_auth_hash
+      expect(mock_auth_config).to eq(facebook: auth_hash)
+    end
+
+    it 'builds an auth hash based on the provided data' do
+      hash_builder = class_double('OmniAuth::AuthHash', new: double)
+      mock_auth_config = {}
+
+      described_class.new(hash_builder: hash_builder, mock_auth_config: mock_auth_config).stub_auth_hash(
+        id: 79911749339938642,
+        name: 'Lauretta Kertzmann',
+        token: '237699305323155|dc16f036399dda7bc8f140701a901a4f'
+      )
+
+      expect(hash_builder).to have_received(:new).with(
+        'provider' => 'facebook',
+        'uid' => 79911749339938642,
+        'info' => {
+          'name' => 'Lauretta Kertzmann',
+          'image' => 'http://graph.facebook.com/v2.10/79911749339938642/picture'
+        },
+        'credentials' => {
+          'token' => '237699305323155|dc16f036399dda7bc8f140701a901a4f',
+          'expires_at' => 1546086985,
+          'expires' => true
+        },
+        'extra' => {
+          'raw_info' => {
+            'name' => 'Lauretta Kertzmann',
+            'id' => 79911749339938642
+          }
+        }
+      )
+    end
+  end
+end

--- a/spec/support/system/omniauth_helper.rb
+++ b/spec/support/system/omniauth_helper.rb
@@ -5,35 +5,8 @@ module System
     OmniAuth.config.test_mode = true
     OmniAuth.config.logger = Logger.new('/dev/null')
 
-    def stub_auth_hash(
-      id: Faker::Number.number(17),
-      name: Faker::Name.name,
-      token: SecureRandom.hex
-    )
-      auth_hash = facebook_auth_hash(id: id, name: name, token: token)
-      OmniAuth.config.mock_auth[:facebook] = auth_hash
-    end
-
-    def facebook_auth_hash(id:, name:, token:)
-      OmniAuth::AuthHash.new(
-        'provider' => 'facebook',
-        'uid' => id,
-        'info' => {
-          'name' => name,
-          'image' => "http://graph.facebook.com/v2.10/#{id}/picture"
-        },
-        'credentials' => {
-          'token' => token,
-          'expires_at' => 1546086985,
-          'expires' => true
-        },
-        'extra' => {
-          'raw_info' => {
-            'name' => id,
-            'id' => id
-          }
-        }
-      )
+    def stub_auth_hash(*args)
+      OmniauthTestResponseBuilder.new.stub_auth_hash(*args)
     end
   end
 end


### PR DESCRIPTION
Now that we're using data from the auth hash, we can't rely on the
default omniauth test hash anymore.