### PR TITLE
(fix) show users their facebook ID

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -11,7 +11,8 @@ class SessionsController < ApplicationController
       login_session.log_in!(auth_id: user.id, name: user.name, token: user.token)
       redirect_to events_path
     else
-      flash.alert = 'We didn\'t recognise your facebook account'
+      flash.alert = "Your Facebook ID for Swing Out London (#{user.id}) isn't in the approved list.\n" \
+        "If you've been invited to become an admin, please contact the main site admins and get them to add this ID"
       logger.warn("Auth id #{user.id} tried to log in, but was not in the allowed list")
       redirect_to action: :new
     end

--- a/spec/system/admins_can_login_spec.rb
+++ b/spec/system/admins_can_login_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Admin Login' do
   end
 
   context "when the user isn't in the approved list" do
-    it 'disallows the user from signing in' do
+    it 'disallows the user from signing in, but shows them their Facebook ID' do
       stub_auth_hash(id: 76543210987654321, name: 'Fred Astaire')
       allow(Rails.application.config.x.facebook)
         .to receive(:admin_user_ids)
@@ -31,7 +31,7 @@ RSpec.describe 'Admin Login' do
 
       click_on 'Log in with Facebook'
 
-      expect(page).to have_content('We didn\'t recognise your facebook account')
+      expect(page).to have_content('Your Facebook ID for Swing Out London (76543210987654321) isn\'t in the approved list')
       expect(page).not_to have_header('Events')
     end
   end


### PR DESCRIPTION
I had misunderstood uids: the ID we see in the app isn't actually the
user's profile ID: it's an app-specific ID. The idea is to maintain
privacy, and I guess to not be able to identify the same user between
two different apps:

https://stackoverflow.com/questions/23958890/is-there-a-difference-between-facebook-profile-id-and-uid/23959831#23959831

Rather than pre-approving, let's invert the problem and have the users
tell us their IDs.