### PR TITLE
FIX: Replace action cache with Fragment cache

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class EventsController < CMSBaseController
-  caches_action :index, cache_path: 'events#index'
-  cache_sweeper :event_sweeper, only: %i[create update destroy archive]
-
   def index
     @current_events = Event.current.includes(:venue, :social_organiser, :class_organiser).order('frequency, updated_at')
     @gigs = Event.gigs.includes(:venue, :social_organiser, :class_organiser).order('title')

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -10,8 +10,10 @@ class Event < ApplicationRecord
   belongs_to :venue
   belongs_to :class_organiser, class_name: 'Organiser', optional: true
   belongs_to :social_organiser, class_name: 'Organiser', optional: true
-  has_and_belongs_to_many :swing_dates, -> { distinct(true) }
-  has_and_belongs_to_many :swing_cancellations, -> { distinct(true) }, class_name: 'SwingDate', join_table: 'events_swing_cancellations'
+  has_many :events_swing_dates, dependent: :destroy
+  has_many :swing_dates, -> { distinct(true) }, through: :events_swing_dates
+  has_many :events_swing_cancellations, dependent: :destroy
+  has_many :swing_cancellations, -> { distinct(true) }, through: :events_swing_cancellations, source: :swing_date
 
   serialize :date_array
   serialize :cancellation_array

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -51,11 +51,11 @@ class Event < ApplicationRecord
   SEE_WEB = '(See Website)'
 
   def index_row_cache_key
-    cache_key('index_row')
+    caching_key('index_row')
   end
 
   def status_cache_key
-    cache_key("status_#{Date.today.to_s(:iso)}")
+    caching_key("status_#{Date.today.to_s(:iso)}")
   end
 
   #########
@@ -144,7 +144,7 @@ class Event < ApplicationRecord
   scope :current, -> { active.non_gigs }
   scope :archived, -> { ended.non_gigs }
 
-  def cache_key(suffix)
+  def caching_key(suffix)
     "event_#{id}_#{suffix}"
   end
 
@@ -153,7 +153,7 @@ class Event < ApplicationRecord
   # ----- #
 
   def dates_cache_key
-    cache_key('dates')
+    caching_key('dates')
   end
 
   def dates
@@ -249,16 +249,6 @@ class Event < ApplicationRecord
     elsif near_out_of_date
       'near_out_of_date'
     end
-  end
-
-  def cached_status_string
-    Rails.cache.fetch(status_cache_key) do
-      status_string
-    end
-  end
-  after_save :clear_status_string_cache
-  def clear_status_string_cache
-    Rails.cache.delete(status_cache_key)
   end
 
   # TODO: these should be done in the db, not in ruby
@@ -388,7 +378,7 @@ class Event < ApplicationRecord
   end
 
   def latest_date_cache_key
-    cache_key('latest_date')
+    caching_key('latest_date')
   end
 
   # What's the Latest date in the date array

--- a/app/models/events_swing_cancellation.rb
+++ b/app/models/events_swing_cancellation.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class EventsSwingCancellation < ApplicationRecord
+  belongs_to :event, touch: true
+  belongs_to :swing_date
+end

--- a/app/models/events_swing_date.rb
+++ b/app/models/events_swing_date.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class EventsSwingDate < ApplicationRecord
+  belongs_to :event, touch: true
+  belongs_to :swing_date
+end

--- a/app/presenters/last_update.rb
+++ b/app/presenters/last_update.rb
@@ -21,7 +21,7 @@ class LastUpdate
   end
 
   def updated_at
-    last_audit&.created_at || resource.updated_at
+    resource.updated_at
   end
 
   def last_audit

--- a/app/views/events/_event_listing_table.html.haml
+++ b/app/views/events/_event_listing_table.html.haml
@@ -11,23 +11,4 @@
     %th.dates     Dates
     %th.updated   Last updated
 
-  -events.each do |event|
-    %tr{ :class => event.cached_status_string, :id => "event_#{event.id}" }
-      - cache(event.index_row_cache_key) do
-        -# This cache is expired by EventSweeper
-        %td.actions.first= link_to 'Show', event
-
-        %td.name=         link_to event.title, event.url
-        %td.venue=        link_to event.venue_name, event.venue
-        %td.area=         event.venue_area
-        %td.class_org=    organiser_link(event.class_organiser)
-        %td.soc_org=      organiser_link(event.social_organiser)
-        %td.day=          event.day[0..2]
-        %td.fq.center=    event.frequency
-        %td.dates<=       event.print_dates_rows
-        %td.updated=      event.updated_at.to_s(:uk_date)
-
-        %td.actions.last
-          = link_to 'Edit', edit_event_path(event)
-          = link_to 'Delete', event, data: { confirm: 'Are you sure you want to delete this event?' }, method: :delete
-          = link_to 'Archive', archive_event_path(event), :method => :put
+  = render partial: 'events/event_listing_table_row', collection: events, as: :event

--- a/app/views/events/_event_listing_table_row.html.haml
+++ b/app/views/events/_event_listing_table_row.html.haml
@@ -1,0 +1,22 @@
+- cache [event, event.venue, event.social_organiser, event.class_organiser] do
+  %tr{ :class => event.status_string, :id => "event_#{event.id}" }
+    %td.actions.first= link_to 'Show', event
+
+    %td.name= link_to event.title, event.url
+    %td.venue
+      = link_to event.venue_name, event.venue
+    %td.area
+      = event.venue_area
+    %td.class_org
+      = organiser_link(event.class_organiser)
+    %td.soc_org
+      = organiser_link(event.social_organiser)
+    %td.day= event.day[0..2]
+    %td.fq.center= event.frequency
+    %td.dates<= event.print_dates_rows
+    %td.updated= event.updated_at.to_s(:uk_date)
+
+    %td.actions.last
+      = link_to 'Edit', edit_event_path(event)
+      = link_to 'Delete', event, data: { confirm: 'Are you sure you want to delete this event?' }, method: :delete
+      = link_to 'Archive', archive_event_path(event), :method => :put

--- a/db/migrate/20181114233827_add_primary_key_to_events_swing_dates.rb
+++ b/db/migrate/20181114233827_add_primary_key_to_events_swing_dates.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPrimaryKeyToEventsSwingDates < ActiveRecord::Migration[5.2]
+  def change
+    add_column :events_swing_dates, :id, :primary_key
+  end
+end

--- a/db/migrate/20181114235445_add_primary_key_to_events_swing_cancellations.rb
+++ b/db/migrate/20181114235445_add_primary_key_to_events_swing_cancellations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPrimaryKeyToEventsSwingCancellations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :events_swing_cancellations, :id, :primary_key
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -68,13 +68,13 @@ ActiveRecord::Schema.define(version: 2018_11_18_151929) do
     t.index ["venue_id"], name: "index_events_on_venue_id"
   end
 
-  create_table "events_swing_cancellations", id: false, force: :cascade do |t|
+  create_table "events_swing_cancellations", force: :cascade do |t|
     t.integer "swing_date_id", null: false
     t.integer "event_id", null: false
     t.index ["swing_date_id", "event_id"], name: "index_events_swing_cancellations_on_swing_date_id_and_event_id", unique: true
   end
 
-  create_table "events_swing_dates", id: false, force: :cascade do |t|
+  create_table "events_swing_dates", force: :cascade do |t|
     t.integer "swing_date_id", null: false
     t.integer "event_id", null: false
     t.index ["swing_date_id", "event_id"], name: "index_events_swing_dates_on_swing_date_id_and_event_id", unique: true

--- a/spec/presenters/last_update_spec.rb
+++ b/spec/presenters/last_update_spec.rb
@@ -49,19 +49,5 @@ RSpec.describe LastUpdate do
         expect(update.time_in_words).to eq 'on Friday 12th March 1926 at 12:01:00'
       end
     end
-
-    context 'when the most recent update was to one of the dates' do
-      it 'is the time of the last update in words' do
-        resource_updated_at = Time.utc(1926, 3, 12, 12, 1, 0).in_time_zone('London')
-        dates_updated_at = Time.utc(2018, 11, 15, 23, 14, 14).in_time_zone('London')
-        audit = instance_double('Audited::Audit', created_at: dates_updated_at)
-        resource = instance_double('Venue', updated_at: resource_updated_at, audits: [audit])
-        editor_builder = class_double('Editor')
-
-        update = described_class.new(resource, editor_builder: editor_builder)
-
-        expect(update.time_in_words).to eq 'on Thursday 15th November 2018 at 23:14:14'
-      end
-    end
   end
 end


### PR DESCRIPTION
Previously we were caching the whole action, which meant that the username
of the currently logged in user was cached between different user sessions.

Instead let's use fragment caching on the individual rows of the event list
in the admin area. This is also MUCH faster to regenerate, since it's not
rebuilding the whole page every time there's an update - just the rows
which have changed.