### PR TITLE
(fix) Add dates to audit log

### DIFF
--- a/app/views/audit_logs/show.html.haml
+++ b/app/views/audit_logs/show.html.haml
@@ -8,3 +8,4 @@
     %span{ class: 'action'}= audit.action
     %span{ class: 'record'}= "#{audit.auditable_type}(#{audit.auditable_id})"
     %span{ class: 'changes'}= audit.audited_changes.to_json
+    %span{ class: 'changes'}= audit.comment


### PR DESCRIPTION
If only dates were changed, this doesn't show up in the changes -
instead it's stored in the comment field