### PR TITLE
(fix) Tell Gmaps4Rails we use the asset pipeline

### DIFF
--- a/app/views/layouts/map.html.haml
+++ b/app/views/layouts/map.html.haml
@@ -20,24 +20,5 @@
     = yield :listings
 
   = yield :scripts
-  :javascript
-    Gmaps.map.callback = function() {
-      //var layer = new google.maps.BicyclingLayer();
-      //var layer = new google.maps.TransitLayer();
-      //layer.setMap(Gmaps.map.serviceObject);
-
-      //var transitOptions = {
-      //  getTileUrl: function (coord, zoom)
-      //  {
-      //    return "http://mt1.google.com/vt/lyrs=m@155076273,transit:comp|vm:&" + "hl=en&opts=r&s=Galil&z=" + zoom + "&x=" + coord.x + "&y=" + coord.y;
-      //  },
-      //
-      //  tileSize: new google.maps.Size(256, 256),
-      //  isPng: true
-      //};
-      //
-      //var transitMapType = new google.maps.ImageMapType(transitOptions);
-      //Gmaps.map.serviceObject.overlayMapTypes.insertAt(0, transitMapType);
-    }
 
 = render template: 'layouts/application'

--- a/config/initializers/gmaps4rails.rb
+++ b/config/initializers/gmaps4rails.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+def Gmaps4rails.pipeline_enabled?
+  true
+end


### PR DESCRIPTION
We're using an oooooooold version of Gmaps4Rails, from a time when not
everyone was using the asset pipeline, so Gmaps4Rails looked at some Rails
configuration options to see if we were using it, and if we are it doesn't
explicitly try and load any javascripts in the page: it assumes that
they'll be loaded in the pipeline.

In the upgrade to Rails5, that isn't any longer a valid check for the asset
pipeline (the config option it was using no longer exists), so we
monkeypatch that function to always return true instead.