### PR TITLE
(feature) Conditionally display an advert unit

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -82,6 +82,7 @@ RSpec/ExampleLength:
   Exclude:
     - spec/system/**/*_spec.rb
     - spec/models/auth_response_spec.rb
+    - spec/models/advert_spec.rb
     - spec/lib/facebook_graph_api/http_client_spec.rb
     - spec/lib/omniauth_test_response_builder_spec.rb
     - spec/services/revoke_login_spec.rb

--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ end
 
 group :test do
   gem 'capybara'
+  gem 'climate_control'
   gem 'elabs_matchers'
   gem 'launchy'
   gem 'rails-controller-testing' # TODO: refactor tests so that we don't need this

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,7 @@ GEM
       xpath (~> 3.2)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
+    climate_control (0.2.0)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -338,6 +339,7 @@ DEPENDENCIES
   bootsnap
   bullet
   capybara
+  climate_control
   coffee-rails
   dalli
   dotenv-rails

--- a/app/assets/stylesheets/listings.scss
+++ b/app/assets/stylesheets/listings.scss
@@ -130,13 +130,18 @@ $small_font_size: 12px;
 
 #soldn_on_the_web {
   max-width: 500px;
+  text-align: right;
 
   #advert {
     border: 6px double #0f0f0f;
     margin-bottom: 1rem;
     text-align: center;
     text-transform: uppercase;
-    padding: 15px;
+
+    .text {
+      display: inline-block;
+      padding: 15px;
+    }
 
     img {
       display: block;

--- a/app/controllers/website_controller.rb
+++ b/app/controllers/website_controller.rb
@@ -16,6 +16,8 @@ class WebsiteController < ApplicationController
 
     @classes = Event.listing_classes.includes(:venue, :class_organiser, :swing_cancellations)
     @socials_dates = Event.socials_dates(@today)
+
+    @ad = Advert.current
   end
 
   private

--- a/app/models/advert.rb
+++ b/app/models/advert.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class Advert
+  def self.current(env: ENV)
+    return unless env['ADVERT_ENABLED'] == 'true'
+
+    new(
+      url: env.fetch('ADVERT_URL'),
+      image_url: env.fetch('ADVERT_IMAGE_URL'),
+      title: env.fetch('ADVERT_TITLE'),
+      google_id: env.fetch('ADVERT_GOOGLE_ID')
+    )
+  end
+
+  def initialize(url:, image_url:, title:, google_id:)
+    @url = url
+    @image_url = image_url
+    @title = title
+    @google_id = google_id
+  end
+
+  attr_reader :url, :image_url, :title, :google_id
+end

--- a/app/views/website/_advert.html.haml
+++ b/app/views/website/_advert.html.haml
@@ -1,0 +1,7 @@
+%aside#advert
+  - if advert
+    = link_to advert.url, title: advert.title, id: advert.google_id do
+      = image_tag advert.image_url, alt: "Advertisment: #{advert.title}"
+  - else
+    .text
+      = mail_to "swingoutlondon@gmail.com", "Advertise here"

--- a/app/views/website/_listing_navigation.html.haml
+++ b/app/views/website/_listing_navigation.html.haml
@@ -30,8 +30,7 @@
     The listings shown are only a guide. You should always check the source website before making any plans
 
 #soldn_on_the_web
-  %aside#advert
-    = mail_to "swingoutlondon@gmail.com", "Advertise here"
+  = render partial: 'advert', locals: { advert: ad }
 
   - # Foo for the facebook like button:
   #fb-root

--- a/app/views/website/_listing_navigation.html.haml
+++ b/app/views/website/_listing_navigation.html.haml
@@ -30,7 +30,7 @@
     The listings shown are only a guide. You should always check the source website before making any plans
 
 #soldn_on_the_web
-  %p#advert
+  %aside#advert
     = mail_to "swingoutlondon@gmail.com", "Advertise here"
 
   - # Foo for the facebook like button:

--- a/spec/models/advert_spec.rb
+++ b/spec/models/advert_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'app/models/advert'
+
+RSpec.describe Advert do
+  describe '.current' do
+    it 'builds an Advert object based on environment variables' do
+      env = {
+        'ADVERT_ENABLED' => 'true',
+        'ADVERT_URL' => 'https://myevent.co.uk',
+        'ADVERT_IMAGE_URL' => 'https://myevent.co.uk/banner',
+        'ADVERT_TITLE' => 'My Event',
+        'ADVERT_GOOGLE_ID' => 'me-1'
+      }
+
+      advert = described_class.current(env: env)
+
+      expect(advert.url).to eq 'https://myevent.co.uk'
+      expect(advert.image_url).to eq 'https://myevent.co.uk/banner'
+      expect(advert.title).to eq 'My Event'
+      expect(advert.google_id).to eq 'me-1'
+    end
+
+    context 'when the advert is disabled' do
+      it 'returns nil' do
+        env = {
+          'ADVERT_ENABLED' => 'false',
+          'ADVERT_URL' => 'https://myevent.co.uk',
+          'ADVERT_IMAGE_URL' => 'https://myevent.co.uk/banner',
+          'ADVERT_TITLE' => 'My Event',
+          'ADVERT_GOOGLE_ID' => 'me-1'
+        }
+
+        advert = described_class.current(env: env)
+
+        expect(advert).to be_nil
+      end
+    end
+  end
+end

--- a/spec/system/advertising_spec.rb
+++ b/spec/system/advertising_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Advertising' do
+  it 'when no advert is enabled' do
+    ClimateControl.modify(
+      ADVERT_ENABLED: 'false'
+    ) do
+      visit '/'
+    end
+
+    expect(page).to have_link(
+      'Advertise here',
+      href: 'mailto:swingoutlondon@gmail.com'
+    )
+  end
+
+  it 'when an advert is enabled' do
+    ClimateControl.modify(
+      ADVERT_ENABLED: 'true',
+      ADVERT_URL: 'https://myevent.co.uk',
+      ADVERT_IMAGE_URL: 'https://myevent.co.uk/banner',
+      ADVERT_TITLE: 'My Event',
+      ADVERT_GOOGLE_ID: 'me-1'
+    ) do
+      visit '/'
+    end
+
+    expect(page).to have_link(
+      nil,
+      href: 'https://myevent.co.uk',
+      title: 'My Event',
+      id: 'me-1'
+    )
+    expect(page).to have_xpath("//img[@src = 'https://myevent.co.uk/banner' and @alt = 'Advertisment: My Event']")
+  end
+end


### PR DESCRIPTION
- Based on the previous implementation of the LLX advert from f2ecaba
- Configure ads using environment variables
- When no ad is configured, show the fallback "advertise here" message
- The non-semantic div here is required for padding - if the padding is
  done on the anchor element directly then the hover style appears at
  the bottom of the box rather than just below the text.
- Extract to a partial
- Extract Advert to a model object - it should be easy to replace this
  with an ActiveRecord model in future.