### PR TITLE
(fix) path helpers work with ShowEvent

### DIFF
--- a/app/presenters/show_event.rb
+++ b/app/presenters/show_event.rb
@@ -75,6 +75,7 @@ class ShowEvent
            :has_taster?,
            :social_organiser,
            :title,
+           :to_param,
            :url,
            :venue,
            :weekly?,

--- a/spec/presenters/show_event_spec.rb
+++ b/spec/presenters/show_event_spec.rb
@@ -215,6 +215,14 @@ RSpec.describe ShowEvent do
     end
   end
 
+  describe '#to_param' do
+    it 'delegates to the event' do
+      event = instance_double('Event', to_param: '123')
+
+      expect(described_class.new(event).to_param).to eq '123'
+    end
+  end
+
   describe '#url' do
     it 'delegates to the event' do
       event = instance_double('Event', url: 'https://www.blackcotton.com')

--- a/spec/system/admins_can_navigate_spec.rb
+++ b/spec/system/admins_can_navigate_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admins can navigate' do
+  it 'from a show page to an edit page' do
+    stub_login
+    FactoryBot.create(:event, url: 'https://navigating.se')
+
+    visit '/login'
+    click_on 'Log in with Facebook'
+
+    click_on 'Show', match: :first
+
+    click_on 'Edit'
+
+    expect(page).to have_content('Editing event')
+  end
+end


### PR DESCRIPTION
The path helpers call to_param on the target object, which in this case
returned the ShowEvent instance as a string. Delegating to_param to the
event allows the path helpers to work.