### PR TITLE
(fix) Raise if deleting venue with events

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ group :test do
   gem 'launchy'
   gem 'rails-controller-testing' # TODO: refactor tests so that we don't need this
   gem 'selenium-webdriver'
+  gem 'shoulda-matchers'
   gem 'simplecov', require: false
   gem 'timecop'
   gem 'vcr'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -302,6 +302,8 @@ GEM
       childprocess (~> 0.5)
       rubyzip (~> 1.2, >= 1.2.2)
     sexp_processor (4.11.0)
+    shoulda-matchers (4.0.1)
+      activesupport (>= 4.2.0)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -385,6 +387,7 @@ DEPENDENCIES
   rubocop-rspec
   sassc-rails
   selenium-webdriver
+  shoulda-matchers
   simplecov
   test-unit
   timecop

--- a/app/assets/stylesheets/application_cms.scss
+++ b/app/assets/stylesheets/application_cms.scss
@@ -188,6 +188,30 @@ ol.show span {
 
 ol.show li { clear: left; }
 
+ol.show li ul {
+  display: inline-block;
+
+  li {
+    list-style-type: disc;
+  }
+}
+
+.venues.show {
+  section {
+    margin: 20px 0 20px 155px;
+
+    h3 {
+      font-size: 20px;
+      margin-bottom: 10px;
+    }
+
+    ul {
+      list-style-position: inside;
+      list-style-type: disc;
+    }
+  }
+}
+
 .last-updated {
   padding-top: 20px;
   font-style: italic;

--- a/app/assets/stylesheets/cms/forms.scss
+++ b/app/assets/stylesheets/cms/forms.scss
@@ -81,6 +81,11 @@ div.actions {
   margin-left: 155px;
   line-height: 1.5;
   clear: left;
+
+  .inactive {
+    color: $lowlight-colour;
+    font-style: italic;
+  }
 }
 
 // Rails Errors

--- a/app/controllers/venues_controller.rb
+++ b/app/controllers/venues_controller.rb
@@ -7,6 +7,7 @@ class VenuesController < CMSBaseController
 
   def show
     @venue = Venue.find(params[:id])
+    @associated_events = @venue.events.map { |event| AssociatedEvent.new(event) }
     @last_update = LastUpdate.new(@venue)
   end
 

--- a/app/helpers/venues_helper.rb
+++ b/app/helpers/venues_helper.rb
@@ -10,4 +10,11 @@ module VenuesHelper
     end
     tag :tr, { class: class_string, id: "venue_#{venue.id}" }, true
   end
+
+  def conditional_delete_tag(venue)
+    confirmation = 'Are you sure you want to delete this venue?'
+    link_to_if venue.can_delete?, 'Delete', venue, confirm: confirmation, method: :delete do
+      content_tag :span, "Can't be deleted: has associated events", class: 'inactive'
+    end
+  end
 end

--- a/app/models/venue.rb
+++ b/app/models/venue.rb
@@ -6,7 +6,7 @@ class Venue < ApplicationRecord
               longitude: :lng
   audited
 
-  has_many :events
+  has_many :events, dependent: :restrict_with_exception
 
   scope :all_with_classes_listed, -> { where(id: Event.listing_classes.select('distinct venue_id')) }
   scope :all_with_classes_listed_on_day, ->(day) { where(id: Event.listing_classes_on_day(day).select('distinct venue_id')) }

--- a/app/models/venue.rb
+++ b/app/models/venue.rb
@@ -23,7 +23,6 @@ class Venue < ApplicationRecord
       end
     end
   end
-
   UNKNOWN_POSTCODE = '???'
 
   def outward_postcode
@@ -54,6 +53,10 @@ class Venue < ApplicationRecord
 
   def coordinates
     "[ #{lat}, #{lng} ]"
+  end
+
+  def can_delete?
+    events.empty?
   end
 
   def self.geocode_all

--- a/app/presenters/associated_event.rb
+++ b/app/presenters/associated_event.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class AssociatedEvent
+  def initialize(event, summarizer: EventSummarizer.new, url_helpers: Rails.application.routes.url_helpers)
+    @event = event
+    @summarizer = summarizer
+    @url_helpers = url_helpers
+  end
+
+  def summary
+    summarizer.summarize(event)
+  end
+
+  def link
+    url_helpers.event_path(event)
+  end
+
+  private
+
+  attr_reader :event, :summarizer, :url_helpers
+end

--- a/app/services/event_summarizer.rb
+++ b/app/services/event_summarizer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class EventSummarizer
+  def summarize(event)
+    if event.has_social?
+      "Social: #{event.title}"
+    else
+      "Class with #{event.class_organiser.name} on #{event.day.pluralize}"
+    end
+  end
+end

--- a/app/views/venues/edit.html.erb
+++ b/app/views/venues/edit.html.erb
@@ -3,7 +3,7 @@
 <%= render :partial => 'new_or_edit_fields', :locals => { :action => 'Update' }%>
 
 <div class="actions">
-	<%= link_to 'Show', @venue %> |
-	<%= link_to 'Back', venues_path %> |
-	<%= link_to 'Delete', @venue, :confirm => 'Are you sure you want to delete this venue?', :method => :delete %>
+  <%= link_to 'Show', @venue %> |
+  <%= link_to 'Back', venues_path %> |
+  <%= conditional_delete_tag(@venue) %>
 </div>

--- a/app/views/venues/index.html.erb
+++ b/app/views/venues/index.html.erb
@@ -20,7 +20,9 @@
     <td class="actions">
       <%= link_to 'Show', venue %>
       <%= link_to 'Edit', edit_venue_path(venue) %>
-      <%= link_to 'Destroy', venue, :confirm => 'Are you sure?', :method => :delete %>
+      <% if venue.can_delete? %>
+        <%= link_to 'Delete', venue, confirm: 'Are you sure?', method: :delete %>
+      <% end %>
     </td>
   </tr>
 <% end %>

--- a/app/views/venues/show.html.erb
+++ b/app/views/venues/show.html.erb
@@ -39,7 +39,7 @@
 
 <div class="actions">
   <%= link_to 'Edit', edit_venue_path(@venue) %>  |
-  <%= link_to 'Delete', @venue, data: { confirm: 'Are you sure you want to delete this venue?' }, method: :delete %> |
+  <%= conditional_delete_tag(@venue) %> |
   <%= link_to 'List', venues_path(anchor: "venue_#{@venue.id}") %> |
   <%= link_to 'New venue', new_venue_path %> |
   <%= link_to 'New Event at this venue',  new_event_path( venue_id: @venue.id) %>

--- a/app/views/venues/show.html.erb
+++ b/app/views/venues/show.html.erb
@@ -37,6 +37,17 @@
   </li>
 </ol>
 
+<% if @associated_events.any? %>
+  <section>
+    <h3>Associated Events</h3>
+    <ul>
+      <% @associated_events.each do |event| %>
+        <li><%= link_to event.summary, event.link %></li>
+      <% end %>
+    </ul>
+  </section>
+<% end %>
+
 <div class="actions">
   <%= link_to 'Edit', edit_venue_path(@venue) %>  |
   <%= conditional_delete_tag(@venue) %> |

--- a/spec/models/venue_spec.rb
+++ b/spec/models/venue_spec.rb
@@ -7,4 +7,19 @@ RSpec.describe Venue do
   describe 'Associations' do
     it { is_expected.to have_many(:events).dependent(:restrict_with_exception) }
   end
+
+  describe 'can_delete?' do
+    it 'is true if there are no associated events' do
+      venue = FactoryBot.build(:venue)
+
+      expect(venue.can_delete?).to eq true
+    end
+
+    it 'is false if there are associated events' do
+      venue = FactoryBot.create(:venue)
+      FactoryBot.create(:event, venue: venue)
+
+      expect(venue.can_delete?).to eq false
+    end
+  end
 end

--- a/spec/models/venue_spec.rb
+++ b/spec/models/venue_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'support/shoulda_matchers'
+
+RSpec.describe Venue do
+  describe 'Associations' do
+    it { is_expected.to have_many(:events).dependent(:restrict_with_exception) }
+  end
+end

--- a/spec/presenters/associated_event_spec.rb
+++ b/spec/presenters/associated_event_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'app/presenters/associated_event'
+
+RSpec.describe AssociatedEvent do
+  describe '#summary' do
+    it 'builds a summary from the event' do
+      event = instance_double('Event')
+      summarizer = instance_double('EventSummarizer', summarize: 'A summary of the event')
+
+      associated_event = described_class.new(event, summarizer: summarizer, url_helpers: double)
+
+      expect(associated_event.summary).to eq 'A summary of the event'
+    end
+  end
+
+  describe '#link' do
+    it 'links to the event' do
+      event = instance_double('Event')
+      url_helpers = instance_double('Rails.application.routes.url_helpers')
+      allow(url_helpers).to receive(:event_path).with(event).and_return('/path/to/event')
+
+      associated_event = described_class.new(event, summarizer: double, url_helpers: url_helpers)
+
+      expect(associated_event.link).to eq '/path/to/event'
+    end
+  end
+end

--- a/spec/services/event_summarizer_spec.rb
+++ b/spec/services/event_summarizer_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'active_support/core_ext/string/inflections'
+require 'app/services/event_summarizer'
+
+RSpec.describe EventSummarizer do
+  describe 'to_s' do
+    context 'when the event is a social' do
+      it 'returns the title' do
+        event = instance_double('Event',
+                                has_social?: true,
+                                title: 'Jitterbugs')
+        summary = described_class.new.summarize(event)
+
+        expect(summary).to eq 'Social: Jitterbugs'
+      end
+    end
+
+    context 'when the event is a class' do
+      it 'returns the organiser and day' do
+        organiser = instance_double('Organiser', name: 'Sing Lim')
+        event = instance_double('Event',
+                                has_social?: false,
+                                day: 'Thursday',
+                                class_organiser: organiser)
+
+        summary = described_class.new.summarize(event)
+
+        expect(summary).to eq 'Class with Sing Lim on Thursdays'
+      end
+    end
+  end
+end

--- a/spec/support/shoulda_matchers.rb
+++ b/spec/support/shoulda_matchers.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end

--- a/spec/system/admins_can_create_events_spec.rb
+++ b/spec/system/admins_can_create_events_spec.rb
@@ -49,4 +49,37 @@ RSpec.describe 'Admins can create events' do
 
     expect(page).to have_content('Last updated by Al Minns (12345678901234567) on Sunday 2nd January 2000 at 23:17:16')
   end
+
+  it 'with missing data' do
+    stub_login(id: 12345678901234567, name: 'Al Minns')
+    FactoryBot.create(:venue, name: 'The 100 Club')
+
+    visit '/login'
+    click_on 'Log in with Facebook'
+
+    click_on 'New event', match: :first
+
+    click_on 'Create'
+
+    expect(page).to have_content('6 errors prohibited this record from being saved')
+      .and have_content('Venue must exist')
+      .and have_content('Url is invalid')
+      .and have_content("Url can't be blank")
+      .and have_content("Event type can't be blank")
+      .and have_content("Frequency can't be blank")
+      .and have_content('Events must have either a Social or a Class')
+
+    select 'The 100 Club', from: 'Venue'
+    select 'school', from: 'Event type'
+    check 'Has social?'
+    fill_in 'event_frequency', with: '1'
+    fill_in 'Url', with: 'http://www.lsds.co.uk/stompin'
+
+    click_on 'Create'
+
+    expect(page).to have_content('Venue: The 100 Club')
+      .and have_content('school, with social')
+      .and have_content('Frequency: Weekly')
+      .and have_content('Url: http://www.lsds.co.uk/stompin')
+  end
 end

--- a/spec/system/admins_can_delete_venues_spec.rb
+++ b/spec/system/admins_can_delete_venues_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Admins can delete venues' do
 
     click_on 'Venues', match: :first
 
-    click_on 'Destroy', match: :first
+    click_on 'Delete', match: :first
 
     expect(page).to have_content('Events')
     expect(page).to have_no_content('Destroy')
@@ -29,11 +29,19 @@ RSpec.describe 'Admins can delete venues' do
 
     click_on 'Venues', match: :first
 
-    click_on 'Edit', match: :first
+    expect(page).to have_no_content('Destroy')
+    expect(page).to have_no_content('Delete')
 
-    expect do
-      click_on 'Delete', match: :first
-    end
-      .to raise_error(ActiveRecord::DeleteRestrictionError)
+    click_on 'Show'
+
+    expect(page).to have_no_content('Destroy')
+    expect(page).to have_no_content('Delete')
+    expect(page).to have_content("Can't be deleted: has associated events")
+
+    click_on 'Edit'
+
+    expect(page).to have_no_content('Destroy')
+    expect(page).to have_no_content('Delete')
+    expect(page).to have_content("Can't be deleted: has associated events")
   end
 end

--- a/spec/system/admins_can_delete_venues_spec.rb
+++ b/spec/system/admins_can_delete_venues_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admins can delete venues' do
+  it 'when the venue has no associated events' do
+    stub_login
+    FactoryBot.create(:venue, name: "Bobby McGee's")
+
+    visit '/login'
+    click_on 'Log in with Facebook'
+
+    click_on 'Venues', match: :first
+
+    click_on 'Destroy', match: :first
+
+    expect(page).to have_content('Events')
+    expect(page).to have_no_content('Destroy')
+    expect(page).to have_no_content("Bobby McGee's")
+  end
+
+  it 'when the venue has associated events' do
+    stub_login
+    venue = FactoryBot.create(:venue)
+    FactoryBot.create(:event, venue: venue)
+
+    visit '/login'
+    click_on 'Log in with Facebook'
+
+    click_on 'Venues', match: :first
+
+    click_on 'Edit', match: :first
+
+    expect do
+      click_on 'Delete', match: :first
+    end
+      .to raise_error(ActiveRecord::DeleteRestrictionError)
+  end
+end

--- a/spec/system/admins_can_see_associated_events_on_venues_spec.rb
+++ b/spec/system/admins_can_see_associated_events_on_venues_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admins can see associated events on venues' do
+  it 'when there are associated events' do
+    stub_login
+    venue = FactoryBot.create(:venue)
+    organiser = FactoryBot.create(:organiser, name: 'Ron and Christine')
+    dance_class = FactoryBot.create(:class, class_organiser: organiser, day: 'Wednesday', venue: venue)
+    social = FactoryBot.create(:social, title: 'The Sunday Stomp', venue: venue)
+
+    visit '/login'
+    click_on 'Log in with Facebook'
+
+    click_on 'Venues'
+
+    click_on 'Show'
+
+    expect(page).to have_content('Associated Events')
+    expect(page).to have_link('Class with Ron and Christine on Wednesdays', href: event_path(dance_class))
+    expect(page).to have_link('Social: The Sunday Stomp', href: event_path(social))
+  end
+
+  it 'when there are no associated events' do
+    stub_login
+    FactoryBot.create(:venue)
+
+    visit '/login'
+    click_on 'Log in with Facebook'
+
+    click_on 'Venues'
+
+    click_on 'Show'
+
+    expect(page).to have_no_content('Associated Events')
+  end
+end


### PR DESCRIPTION
Raise an exception if we try to delete a venue which has associated events.

This is kind of a blunt instrument since it doesn't tell the editing user
why they're getting an error, but it keeps us safe.

Previously on production we've deleted venues with live associated events
and this has caused the back-end to become unusable:

https://swingoutlondon.freshdesk.com/a/tickets/791
https://swingoutlondon.slack.com/archives/CEL0CHLLD/p1551782023011300

(feature) Show associated events on venues

Since it's not possible to delete venues with associated events, we should
display those events on the venues.