### PR TITLE
(fix) disable deletion of Organisers with events

### DIFF
--- a/app/helpers/form_actions_helper.rb
+++ b/app/helpers/form_actions_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module FormActionsHelper
+  def conditional_delete_tag(resource)
+    confirmation = 'Are you sure you want to delete this?'
+    link_to_if resource.can_delete?, 'Delete', resource, confirm: confirmation, method: :delete do
+      content_tag :span, "Can't be deleted: has associated events", class: 'inactive'
+    end
+  end
+end

--- a/app/helpers/venues_helper.rb
+++ b/app/helpers/venues_helper.rb
@@ -10,11 +10,4 @@ module VenuesHelper
     end
     tag :tr, { class: class_string, id: "venue_#{venue.id}" }, true
   end
-
-  def conditional_delete_tag(venue)
-    confirmation = 'Are you sure you want to delete this venue?'
-    link_to_if venue.can_delete?, 'Delete', venue, confirm: confirmation, method: :delete do
-      content_tag :span, "Can't be deleted: has associated events", class: 'inactive'
-    end
-  end
 end

--- a/app/views/organisers/edit.html.erb
+++ b/app/views/organisers/edit.html.erb
@@ -1,9 +1,9 @@
 <h1>Editing organiser</h1>
 
-<%=render :partial => "new_or_edit_fields", :locals => {:action => "Update" } %>
+<%= render partial: "new_or_edit_fields", locals: {action: "Update" } %>
 
 <div class="actions">
-	<%= link_to 'Show', @organiser %> |
-	<%= link_to 'Back', organisers_path %> |
-	<%= link_to 'Delete', @organiser, :confirm => 'Are you sure you want to delete this organiser?', :method => :delete %>
+  <%= link_to 'Show', @organiser %> |
+  <%= link_to 'Back', organisers_path %> |
+  <%= conditional_delete_tag(@organiser) %> |
 </div>

--- a/app/views/organisers/index.html.erb
+++ b/app/views/organisers/index.html.erb
@@ -8,17 +8,19 @@
     <th>Description</th>
   </tr>
 
-<% @organisers.each do |organiser| %>
-  <%= organiser_row_tag(organiser) %>
+  <% @organisers.each do |organiser| %>
+    <%= organiser_row_tag(organiser) %>
     <td><%= link_to_unless organiser.website.nil?, organiser.name, organiser.website %></td>
     <td><%=h organiser.description %></td>
     <td class="actions">
-		<%= link_to 'Show', organiser %>
-	    <%= link_to 'Edit', edit_organiser_path(organiser) %>
-	    <%= link_to 'Destroy', organiser, :confirm => 'Are you sure?', :method => :delete %>
-	</td>
-  </tr>
-<% end %>
+      <%= link_to 'Show', organiser %>
+      <%= link_to 'Edit', edit_organiser_path(organiser) %>
+      <% if organiser.can_delete? %>
+        <%= link_to 'Delete', organiser, confirm: 'Are you sure?', method: :delete %>
+      <% end %>
+    </td>
+    </tr>
+  <% end %>
 </table>
 
 <br />

--- a/app/views/organisers/show.html.erb
+++ b/app/views/organisers/show.html.erb
@@ -23,7 +23,7 @@
 
 <div class="actions">
   <%= link_to 'Edit', edit_organiser_path(@organiser) %> |
-  <%= link_to 'Delete', @organiser, data: { confirm: 'Are you sure you want to delete this organiser?' }, method: :delete %> |
+  <%= conditional_delete_tag(@organiser) %> |
   <%= link_to 'List', organisers_path(anchor: "organiser_#{@organiser.id}")%> |
   <%= link_to 'New organiser', new_organiser_path %> |
   <%= link_to 'New Event by this organiser',  new_event_path( organiserid: @organiser.id) %>

--- a/spec/models/organiser_spec.rb
+++ b/spec/models/organiser_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'support/shoulda_matchers'
+
+RSpec.describe Organiser do
+  describe 'Associations' do
+    it { is_expected.to have_many(:classes).dependent(:restrict_with_exception) }
+    it { is_expected.to have_many(:socials).dependent(:restrict_with_exception) }
+  end
+
+  describe 'can_delete?' do
+    it 'is true if there are no associated events' do
+      organiser = FactoryBot.build(:organiser)
+
+      expect(organiser.can_delete?).to eq true
+    end
+
+    it 'is false if there are associated events' do
+      organiser = FactoryBot.create(:organiser)
+      FactoryBot.create(:event, social_organiser: organiser)
+
+      expect(organiser.can_delete?).to eq false
+    end
+  end
+end

--- a/spec/system/admins_can_delete_organisers_spec.rb
+++ b/spec/system/admins_can_delete_organisers_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admins can delete organisers' do
+  it 'when the organiser has no associated events' do
+    stub_login
+    FactoryBot.create(:organiser, name: 'Herbert White')
+
+    visit '/login'
+    click_on 'Log in with Facebook'
+
+    click_on 'Organisers', match: :first
+
+    click_on 'Delete', match: :first
+
+    expect(page).to have_content('Events')
+    expect(page).to have_no_content('Destroy')
+    expect(page).to have_no_content('Herbert White')
+  end
+
+  it 'when the organiser has associated events' do
+    stub_login
+    organiser = FactoryBot.create(:organiser)
+    FactoryBot.create(:event, social_organiser: organiser)
+
+    visit '/login'
+    click_on 'Log in with Facebook'
+
+    click_on 'Organisers', match: :first
+
+    expect(page).to have_no_content('Destroy')
+    expect(page).to have_no_content('Delete')
+
+    click_on 'Show'
+
+    expect(page).to have_no_content('Destroy')
+    expect(page).to have_no_content('Delete')
+    expect(page).to have_content("Can't be deleted: has associated events")
+
+    click_on 'Edit'
+
+    expect(page).to have_no_content('Destroy')
+    expect(page).to have_no_content('Delete')
+    expect(page).to have_content("Can't be deleted: has associated events")
+  end
+end


### PR DESCRIPTION
This hasn't happened, but would probably break things.

Exactly the same pattern as for venues.