### PR TITLE
Upgrade vulnerable Nokogiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,7 +176,7 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     nio4r (2.3.1)
-    nokogiri (1.10.3)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     oauth2 (1.4.1)
       faraday (>= 0.8, < 0.16.0)


### PR DESCRIPTION
CVE-2019-5477
Vulnerable versions: < 1.10.4
Patched version: 1.10.4