### PR TITLE
Add non-semantic padding to banner

### DIFF
--- a/app/views/layouts/website.html.haml
+++ b/app/views/layouts/website.html.haml
@@ -18,6 +18,7 @@
     .banner
       %h3= ENV['BANNER_HEAD']
       %p=  ENV['BANNER_BODY']
+    .non-semantic-padding
 
   #page
     #header


### PR DESCRIPTION
Make sure that when the banner displays, it doesn't cover the site title