### PR TITLE
Fix: display of listing info

### DIFF
--- a/app/helpers/listings_helper.rb
+++ b/app/helpers/listings_helper.rb
@@ -94,17 +94,30 @@ module ListingsHelper
   end
 
   def mapinfo_class_info_tag(social)
-    class_info = []
-    class_info << social.class_style if social.class_style.present?
-    class_info << if social.has_class?
-                    'class'
-                  else
-                    'taster'
-                  end
-    class_info << "by #{school_name(social)}" if school_name(social)
+    class_info = capture do
+      if social.class_style.present?
+        concat social.class_style
+        concat ' '
+      end
+
+      class_type =
+        if social.has_class?
+          'class'
+        else
+          'taster'
+        end
+      concat class_type
+
+      if school_name(social)
+        concat ' by '
+        concat school_name(social)
+      end
+    end
 
     tag.span class: 'info' do
-      "(#{class_info.join(' ')})"
+      concat '('
+      concat class_info
+      concat ')'
     end
   end
 
@@ -136,13 +149,9 @@ module ListingsHelper
   end
 
   def swingclass_link(event)
-    info = swingclass_info(event)
     text = capture do
       concat swingclass_details(event)
-      if info.any?
-        concat ' '
-        concat tag.span info.join(' '), class: 'info'
-      end
+      concat tag.span swingclass_info(event), class: 'info' if swingclass_info(event)
     end
 
     if event.url.nil?
@@ -163,20 +172,23 @@ module ListingsHelper
   end
 
   def swingclass_info(event)
-    swingclass_info = []
-    swingclass_info << "at #{event.title}" if event.has_social?
-    swingclass_info << "with #{school_name(event)}" if school_name(event)
-    swingclass_info
+    capture do
+      if event.has_social?
+        concat ' '
+        concat "at #{event.title}"
+      end
+
+      if school_name(event)
+        concat ' with '
+        concat school_name(event)
+      end
+    end
   end
 
   def mapinfo_swingclass_link(event)
-    info = swingclass_info(event)
     text = capture do
       concat mapinfo_swingclass_details(event)
-      if info.any?
-        concat ' '
-        concat tag.span info.join(' '), class: 'info'
-      end
+      concat tag.span swingclass_info(event), class: 'info' if swingclass_info(event)
     end
 
     if event.url.nil?

--- a/spec/system/smoke_spec.rb
+++ b/spec/system/smoke_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe 'Adding a new event' do
     click_on 'New Organiser'
 
     fill_in 'Name', with: 'Frankie Manning'
+    fill_in 'Shortname', with: 'Frankie'
 
     click_on 'Update'
 
@@ -83,9 +84,13 @@ RSpec.describe 'Adding a new event' do
       within page.all('.day_row')[5] do
         expect(page).to have_content 'Saturday'
         expect(page).to have_link 'WC2R', href: "map/classes/Saturday?venue_id=#{venue_id}"
-        expect(page).to have_link 'Harlem (Savoy Style) at Stompin at the Savoy with Frankie Manning', href: 'https://www.savoyballroom.com/stompin'
+        expect(page).to have_link 'Harlem (Savoy Style) at Stompin at the Savoy with Frankie', href: 'https://www.savoyballroom.com/stompin'
         expect(page).to have_content 'Cancelled on 11th Oct'
       end
     end
+
+    expect(page).not_to have_content('<')
+    expect(page).not_to have_content('>')
+    expect(page).not_to have_content('abbr title=')
   end
 end


### PR DESCRIPTION
The issue is that school_name can be plain text, but can also be text
wrapped in an abbr tag (for the abbreviated name). String interpolation
converts that tag to raw text and the tags get rendered as text in the
page.

This is kind of annoying: it feels like there should be a way to do
something similar to join(' ') but with concat.

The alternatives are:

Build everything as a string and then use `raw` to have it display
properly, feels more natural but also like bad practice

Or

Use capture/concat everywhere and kind of simulate writing html: in some
ways this is clean, but it's not at all easy to see what the result of
it all is.