### PR TITLE
Fix: Organisers can handle empty shortnames

### DIFF
--- a/app/models/organiser.rb
+++ b/app/models/organiser.rb
@@ -15,6 +15,14 @@ class Organiser < ApplicationRecord
   validates :shortname, length: { maximum: 20 }
   validates :shortname, uniqueness: { allow_blank: true }
 
+  def shortname=(value)
+    if value.blank?
+      super(nil)
+    else
+      super
+    end
+  end
+
   def events
     Event
       .where(class_organiser_id: id)

--- a/spec/models/organiser_spec.rb
+++ b/spec/models/organiser_spec.rb
@@ -9,6 +9,42 @@ RSpec.describe Organiser do
     it { is_expected.to have_many(:socials).dependent(:restrict_with_exception) }
   end
 
+  describe 'Validations' do
+    it { is_expected.to validate_uniqueness_of(:shortname) }
+  end
+
+  describe 'shortname=' do
+    context 'when the value was not blank' do
+      it 'sets the value' do
+        organiser = FactoryBot.build(:organiser)
+
+        organiser.shortname = 'foo'
+
+        expect(organiser.shortname).to eq 'foo'
+      end
+    end
+
+    context 'when the value was nil' do
+      it 'sets the value' do
+        organiser = FactoryBot.build(:organiser)
+
+        organiser.shortname = nil
+
+        expect(organiser.shortname).to be_nil
+      end
+    end
+
+    context 'when the value was empty' do
+      it 'sets the value to nil' do
+        organiser = FactoryBot.build(:organiser)
+
+        organiser.shortname = ''
+
+        expect(organiser.shortname).to be_nil
+      end
+    end
+  end
+
   describe 'can_delete?' do
     it 'is true if there are no associated events' do
       organiser = FactoryBot.build(:organiser)

--- a/spec/system/admins_can_create_organisations_spec.rb
+++ b/spec/system/admins_can_create_organisations_spec.rb
@@ -27,4 +27,21 @@ RSpec.describe 'Admins can create organisers' do
 
     expect(page).to have_content('Last updated by Al Minns (12345678901234567) on Sunday 2nd January 2000 at 23:17:16')
   end
+
+  it 'with an emtpy shortname' do
+    FactoryBot.create(:organiser, shortname: '')
+    stub_login
+
+    visit '/login'
+    click_on 'Log in with Facebook'
+
+    click_on 'New Organiser'
+
+    fill_in 'Name', with: 'The London Swing Dance Society'
+    fill_in 'Shortname', with: ''
+
+    click_on 'Update'
+
+    expect(page).to have_content('Last updated by')
+  end
 end


### PR DESCRIPTION
https://rollbar.com/swingoutlondon/SOLDN/items/81/

The issue is that we have a unique index in Postgres on shortname (maybe
not really needed?), and that allows multiple nil records, but not
multiple empty strings.

Somehow the way the other SOLDN editors are working means that sometimes
when this field is blank it submits an empty string, so we've gotten a
uniqueness error in production.

I don't see a super good fix for this, but overriding the setter method
for shortname so that we always set nil if the input is an empty string
does the job.