### PR TITLE
Previously we blindly updated the Dalli gem, but Dalli 3 has some changes:

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -54,8 +54,7 @@ Rails.application.configure do
   config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
-  config.cache_store = :dalli_store
+  config.cache_store = :mem_cache_store, ENV['MEMCACHIER_SERVERS'], { pool_size: 10, pool_timeout: 5 }
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque


### PR DESCRIPTION
https://github.com/petergoldstein/dalli/blob/main/3.0-Upgrade.md

In particular, we need to use Rails' built in mem_cache_store since
dalli_store has been removed.