### PR TITLE
Add connection pool gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gem 'actionpack-action_caching' # to support pre rails-4 style action caching
 gem 'audited'
 gem 'bootsnap'
 gem 'coffee-rails'
-gem 'dalli'
 gem 'geocoder'
 gem 'haml-rails'
 gem 'http'
@@ -64,6 +63,8 @@ group :test do
 end
 
 group :production do
+  gem 'connection_pool'
+  gem 'dalli'
   gem 'oj' # For Rollbar
   gem 'rack-canonical-host'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.9)
+    connection_pool (2.2.5)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -380,6 +381,7 @@ DEPENDENCIES
   capybara
   climate_control
   coffee-rails
+  connection_pool
   dalli
   dotenv-rails
   elabs_matchers


### PR DESCRIPTION
Needed for the caching configuration we've specified in production.rb
Didn't find out about this until I tried to deploy.

Also move dalli to the production group - I think that's the only place
it's used?