### PR TITLE
Enforce: Events with socials must have a title

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -23,6 +23,7 @@ class Event < ApplicationRecord
   validates :course_length, numericality: { only_integer: true, greater_than: 0, allow_nil: true }
 
   validate :cannot_be_weekly_and_have_dates
+  validate :socials_must_have_titles
   validate :will_be_listed
 
   def cannot_be_weekly_and_have_dates
@@ -35,6 +36,13 @@ class Event < ApplicationRecord
     return if has_class? || has_social?
 
     errors[:base] << "Events must have either a Social or a Class, otherwise they won't be listed!"
+  end
+
+  def socials_must_have_titles
+    return unless has_social?
+    return if title.present?
+
+    errors.add(:title, 'must be present for social dances')
   end
 
   # display constants:

--- a/app/views/events/_new_or_edit_fields.html.erb
+++ b/app/views/events/_new_or_edit_fields.html.erb
@@ -18,6 +18,7 @@
   <div class='form-group'>
     <%= f.label :has_social, "Has social?" %>
     <%= f.check_box :has_social  %>
+    <span class='help'>Events with a social dance *must* have a title: this is what gets displayed in the listing</span>
   </div>
   <div class='form-group'>
     <%= f.label :title %>

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -330,6 +330,16 @@ describe Event do
       event.valid?
       expect(event.errors.messages).to eq(venue: ['must exist'])
     end
+
+    it "is valid if it's a class without a title" do
+      expect(FactoryBot.build(:event, has_taster: false, has_social: false, has_class: true, title: nil)).to be_valid
+    end
+
+    it "is invalid if it's a social without a title" do
+      event = FactoryBot.build(:event, has_taster: false, has_social: true, has_class: true, title: nil)
+      event.valid?
+      expect(event.errors.messages).to eq(title: ['must be present for social dances'])
+    end
   end
 
   describe 'expected_date' do

--- a/spec/system/admins_can_create_events_spec.rb
+++ b/spec/system/admins_can_create_events_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe 'Admins can create events' do
     select 'The 100 Club', from: 'Venue'
     select 'school', from: 'Event type'
     check 'Has social?'
+    fill_in 'Title', with: 'Stompin\''
     fill_in 'event_frequency', with: '1'
     fill_in 'Url', with: 'http://www.lsds.co.uk/stompin'
 

--- a/spec/system/map_spec.rb
+++ b/spec/system/map_spec.rb
@@ -59,8 +59,10 @@ RSpec.describe 'Users can view a map of upcoming events' do
     end
 
     context 'when a social has no title (regression test)' do
+      # TODO: delete this and the related functionality when all records have been fixed on production.
       it "silently doesn't render it" do
-        FactoryBot.create(:social, title: nil, dates: [Date.new(2019, 6, 8)])
+        social = FactoryBot.create(:social, dates: [Date.new(2019, 6, 8)])
+        social.update_attribute(:title, nil) # rubocop:disable Rails/SkipsModelValidations
 
         Timecop.freeze(Time.utc(2019, 6, 4, 12)) do
           expect do


### PR DESCRIPTION
The title is what we display in the listing. Currently we're silently
not displaying these, which is unexpected in the main listing, and looks
broken in the map.