### PR TITLE
Show a link if organiser token exists

### DIFF
--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -14,6 +14,16 @@
     <%= f.select :event_type, event_type_select, {:include_blank => true} %>
   </div>
 
+  <% if @event.persisted? %>
+    <h3 class='form-group-title'>Organiser edit link</h3>
+    <% if @event.organiser_token %>
+      <%= edit_external_event_url(@event.organiser_token) %>
+    <% else %>
+      No organiser edit link exists for this event
+    <% end %>
+    <p class='help'>This is a link you can share with an organiser to allow them to add dates and change details</span>
+  <% end %>
+
   <h3 class='form-group-title'>Social details</h3>
   <div class='form-group'>
     <%= f.label :has_social, "Has social?" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :external_events, only: %i[edit]
+
   get 'map/classes/(:day)' => 'maps#classes', as: :map_classes
   get 'map/socials/(:date)' => 'maps#socials', as: :map_socials
   get 'map' => 'maps#socials'

--- a/db/migrate/20220516205058_add_organiser_token_to_events.rb
+++ b/db/migrate/20220516205058_add_organiser_token_to_events.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganiserTokenToEvents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :events, :organiser_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_02_203412) do
+ActiveRecord::Schema.define(version: 2022_05_16_205058) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,6 +59,7 @@ ActiveRecord::Schema.define(version: 2021_12_02_203412) do
     t.integer "class_organiser_id"
     t.integer "social_organiser_id"
     t.date "expected_date"
+    t.string "organiser_token"
     t.index ["event_type"], name: "index_events_on_event_type"
     t.index ["frequency", "day", "has_class"], name: "index_events_on_fq_and_day_and_has_class"
     t.index ["frequency", "day", "has_social"], name: "index_events_on_fq_and_day_and_has_social"

--- a/spec/system/admins_can_copy_organiser_link_spec.rb
+++ b/spec/system/admins_can_copy_organiser_link_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admins can copy an organiser link' do
+  context 'when an organiser token exists' do
+    it 'shows a url which will allow an organiser to edit an event' do
+      stub_login(id: 12345678901234567, name: 'Al Minns')
+      create(:event, organiser_token: 'abc123')
+
+      visit '/login'
+      click_on 'Log in with Facebook'
+
+      click_on 'Edit', match: :first
+
+      expect(page).to have_content('http://www.example.com/external_events/abc123/edit')
+    end
+  end
+
+  context 'when an organiser token does not exist' do
+    it 'shows a message' do
+      stub_login(id: 12345678901234567, name: 'Al Minns')
+      create(:event, organiser_token: nil)
+
+      visit '/login'
+      click_on 'Log in with Facebook'
+
+      click_on 'Edit', match: :first
+
+      expect(page).to have_content('No organiser edit link exists for this event')
+    end
+  end
+end


### PR DESCRIPTION
This is a bit speculative at this point, since the link doesn't do
anything. The idea is that this will allow login to be bypassed to a
special page where organisers can make limited updates.