### PR TITLE
Switch to webdrivers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,11 +54,11 @@ group :test do
   gem 'elabs_matchers'
   gem 'launchy'
   gem 'rails-controller-testing' # TODO: refactor tests so that we don't need this
-  gem 'selenium-webdriver'
   gem 'shoulda-matchers'
   gem 'simplecov', require: false
   gem 'timecop'
   gem 'vcr'
+  gem 'webdrivers', require: false
   gem 'webmock'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,7 +188,7 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.6.0)
     nio4r (2.5.8)
-    nokogiri (1.13.5)
+    nokogiri (1.13.6)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     oauth2 (1.4.9)
@@ -363,6 +363,10 @@ GEM
     unicode-display_width (2.1.0)
     uniform_notifier (1.16.0)
     vcr (6.1.0)
+    webdrivers (5.0.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (~> 4.0)
     webmock (3.14.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -421,13 +425,13 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec (~> 2.9.0)
   sassc-rails
-  selenium-webdriver
   shoulda-matchers
   simplecov
   sprockets (< 4)
   test-unit
   timecop
   vcr
+  webdrivers
   webmock
 
 RUBY VERSION

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,6 +22,8 @@ RSpec.configure do |config|
 
   require 'support/controller/auth_helper'
   require 'support/system/auth_helper'
+  require 'support/system/drivers'
   config.include Controller::AuthHelper, type: :controller
   config.include System::AuthHelper, type: :system
+  config.include System::Drivers, type: :system
 end

--- a/spec/support/system/auth_helper.rb
+++ b/spec/support/system/auth_helper.rb
@@ -6,14 +6,10 @@ require 'faker/facebook'
 module System
   module AuthHelper
     include OmniAuthHelper
+
     RSpec.configure do |config|
       config.before(:each, type: :system) do
         stub_login
-        driven_by :rack_test
-      end
-
-      config.before(:each, type: :system, js: true) do
-        driven_by :selenium_chrome_headless
       end
     end
 

--- a/spec/support/system/drivers.rb
+++ b/spec/support/system/drivers.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'webdrivers/chromedriver'
+
+module System
+  module Drivers
+    RSpec.configure do |config|
+      config.before(:each, type: :system) do
+        driven_by :rack_test
+      end
+
+      config.before(:each, type: :system, js: true) do
+        driven_by :selenium_chrome_headless
+      end
+    end
+  end
+end

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 require 'webmock/rspec'
-WebMock.disable_net_connect!(allow_localhost: true)
+WebMock.disable_net_connect!(
+  allow_localhost: true,
+  allow: 'chromedriver.storage.googleapis.com'
+)


### PR DESCRIPTION
So it turns out we weren't ever running specs with js turned on, and the
code we had for doing so didn't work: got complaints about chromedriver
versions being incompatible with chrome.

The latest way to install these drivers seems to be the webdrivers gem.

For some reason the drivers try to call out to a chrome storage thing. I
don't really understand that but I saw a github issue which seemed to
suggest that it was fine to just let it call out.

While we're at it, move code related to drivers into its own file.