### PR TITLE
Stylelint failures should fail the build

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@
 require File.expand_path('config/application', __dir__)
 
 task lint_styles: :environment do
-  system('yarn run stylelint app/assets/stylesheets')
+  system('yarn run stylelint app/assets/stylesheets') || exit($CHILD_STATUS.exitstatus)
 end
 
 if Rails.env.test?


### PR DESCRIPTION
We need to actually look at the return code of the stylelint script in
ruby - otherwise ruby is like "Well I successfully sent that command to
the system, so I guess that's success?"