### PR TITLE
Fix: archiving events

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -393,7 +393,7 @@ class Event < ApplicationRecord
     # If there's already a last_date in the past, then the event should already be archived!
 
     self[:last_date] = if weekly?
-                         prev_date
+                         Date.local_today.prev_occurring(day.downcase.to_sym)
                        elsif dates.nil?
                          Date.new # Earliest possible ruby date
                        else

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -52,6 +52,55 @@ class Event < ApplicationRecord
   UNKNOWN_ORGANISER = 'Unknown'
   SEE_WEB = '(See Website)'
 
+  class << self
+    # Find the datetime of the most recently updated event
+    def last_updated_datetime
+      # if the db is empty, return the beginning of the epoch:
+      return Time.zone.at(0) if first.nil?
+
+      maximum(:updated_at)
+    end
+
+    def socials_dates(start_date, venue = nil)
+      # build up an array of events occuring on each date
+      output = []
+
+      listing_dates(start_date).each do |date|
+        socials_on_date = socials_on_date(date, venue)
+        output << [date, socials_on_date, cancelled_events_on_date(date)] unless socials_on_date.empty?
+      end
+
+      output
+    end
+
+    def socials_on_date(date, venue = nil)
+      swing_date = SwingDate.find_by(date: date)
+
+      weekly_socials = weekly.socials.active_on(date).on_same_day_of_week(date)
+      if venue
+        socials_on_that_date = weekly_socials.where(venue_id: venue.id)
+        socials_on_that_date += swing_date.events.socials.where(venue_id: venue.id) if swing_date
+      else
+        socials_on_that_date = weekly_socials.includes(:venue)
+        socials_on_that_date += swing_date.events.socials.includes(:venue) if swing_date
+      end
+
+      socials_on_that_date.sort_by(&:title)
+    end
+
+    def cancelled_events_on_date(date)
+      swing_date = SwingDate.find_by(date: date)
+      return [] unless swing_date
+
+      swing_date.cancelled_events.pluck :id
+    end
+
+    def listing_dates(start_date)
+      end_date = start_date + (INITIAL_SOCIALS - 1)
+      (start_date..end_date).to_a
+    end
+  end
+
   # ----- #
   # Venue #
   # ----- #
@@ -352,56 +401,5 @@ class Event < ApplicationRecord
                        end
 
     return true if save!
-  end
-
-  #################
-  # CLASS METHODS #
-  #################
-
-  # Find the datetime of the most recently updated event
-  def self.last_updated_datetime
-    # if the db is empty, return the beginning of the epoch:
-    return Time.zone.at(0) if first.nil?
-
-    maximum(:updated_at)
-  end
-
-  def self.socials_dates(start_date, venue = nil)
-    # build up an array of events occuring on each date
-    output = []
-
-    listing_dates(start_date).each do |date|
-      socials_on_date = socials_on_date(date, venue)
-      output << [date, socials_on_date, cancelled_events_on_date(date)] unless socials_on_date.empty?
-    end
-
-    output
-  end
-
-  def self.socials_on_date(date, venue = nil)
-    swing_date = SwingDate.find_by(date: date)
-
-    weekly_socials = weekly.socials.active_on(date).on_same_day_of_week(date)
-    if venue
-      socials_on_that_date = weekly_socials.where(venue_id: venue.id)
-      socials_on_that_date += swing_date.events.socials.where(venue_id: venue.id) if swing_date
-    else
-      socials_on_that_date = weekly_socials.includes(:venue)
-      socials_on_that_date += swing_date.events.socials.includes(:venue) if swing_date
-    end
-
-    socials_on_that_date.sort_by(&:title)
-  end
-
-  def self.cancelled_events_on_date(date)
-    swing_date = SwingDate.find_by(date: date)
-    return [] unless swing_date
-
-    swing_date.cancelled_events.pluck :id
-  end
-
-  def self.listing_dates(start_date)
-    end_date = start_date + (INITIAL_SOCIALS - 1)
-    (start_date..end_date).to_a
   end
 end

--- a/spec/system/admins_can_archive_events_spec.rb
+++ b/spec/system/admins_can_archive_events_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admins can archive events' do
+  it 'with a weekly event' do
+    skip_login
+    create(:event, frequency: 1, day: 'Sunday')
+
+    visit '/events'
+
+    # 8th Jan 2000 was a saturday
+    Timecop.freeze(Time.zone.local(2000, 1, 8)) do
+      click_on 'Archive', match: :first
+    end
+
+    click_on 'Show', match: :first
+
+    expect(page).to have_content('Last date: Sunday 2nd January')
+  end
+
+  it 'with an occasional event' do
+    skip_login
+    create(:event, frequency: 0, date_array: '02/01/2000')
+
+    visit '/events'
+
+    Timecop.freeze(Time.zone.local(2000, 1, 8)) do
+      click_on 'Archive', match: :first
+    end
+
+    click_on 'Show', match: :first
+
+    expect(page).to have_content('Last date: Sunday 2nd January')
+  end
+end


### PR DESCRIPTION
In 89d295b I removed the prev_date method, mistakenly thinking it wasn't
used. As a result, archiving events was broken.

Now (since Rails 5.2?) we have this neat "prev_occurring" method which does
the same thing natively.