### PR TITLE
Strip attributes before saving

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'rollbar'
 gem 'rss'
 gem 'sassc-rails'
 gem 'sprockets'
+gem 'strip_attributes'
 gem 'test-unit'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -347,6 +347,8 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    strip_attributes (1.13.0)
+      activemodel (>= 3.0, < 8.0)
     temple (0.8.2)
     test-unit (3.5.3)
       power_assert
@@ -426,6 +428,7 @@ DEPENDENCIES
   shoulda-matchers
   simplecov
   sprockets
+  strip_attributes
   test-unit
   timecop
   vcr

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -28,6 +28,8 @@ class Event < ApplicationRecord
   validate :socials_must_have_titles
   validate :will_be_listed
 
+  strip_attributes only: %i[title shortname url]
+
   def cannot_be_weekly_and_have_dates
     return unless weekly? && !dates.empty?
 

--- a/app/models/organiser.rb
+++ b/app/models/organiser.rb
@@ -15,6 +15,8 @@ class Organiser < ApplicationRecord
   validates :shortname, length: { maximum: 20 }
   validates :shortname, uniqueness: { allow_blank: true }
 
+  strip_attributes only: %i[name shortname website]
+
   def shortname=(value)
     if value.blank?
       super(nil)

--- a/app/models/venue.rb
+++ b/app/models/venue.rb
@@ -16,6 +16,8 @@ class Venue < ApplicationRecord
   validates :name, presence: true
   validates :website, format: URI::DEFAULT_PARSER.make_regexp(%w[http https])
 
+  strip_attributes only: %i[name postcode area website]
+
   before_validation do
     if (lat.nil? || lng.nil?) && !geocode
       errors.add :lat, "The address information could not be geocoded.

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -4,6 +4,36 @@ require 'rails_helper'
 require 'support/shoulda_matchers'
 
 describe Event do
+  describe '#title' do
+    it 'strips whitespace before saving' do
+      event = build(:event, title: " \tDance time! ")
+
+      event.valid?
+
+      expect(event.title).to eq('Dance time!')
+    end
+  end
+
+  describe '#shortname' do
+    it 'strips whitespace before saving' do
+      event = build(:event, shortname: " \tDance! ")
+
+      event.valid?
+
+      expect(event.shortname).to eq('Dance!')
+    end
+  end
+
+  describe '#url' do
+    it 'strips whitespace before saving' do
+      event = build(:event, url: " \thttps://dancetime.co.uk ")
+
+      event.valid?
+
+      expect(event.url).to eq('https://dancetime.co.uk')
+    end
+  end
+
   describe '.dates' do
     it 'returns an ordered list of dates' do
       recent_date = create(:swing_date, date: Time.zone.today)

--- a/spec/models/organiser_spec.rb
+++ b/spec/models/organiser_spec.rb
@@ -13,14 +13,35 @@ RSpec.describe Organiser do
     it { is_expected.to validate_uniqueness_of(:shortname) }
   end
 
+  describe '#name' do
+    it 'strips whitespace before saving' do
+      organiser = build(:organiser, name: " \tHerbert White ")
+
+      organiser.valid?
+
+      expect(organiser.name).to eq('Herbert White')
+    end
+  end
+
+  describe '#website' do
+    it 'strips whitespace before saving' do
+      organiser = build(:organiser, website: " \thttps://whitey.com ")
+
+      organiser.valid?
+
+      expect(organiser.website).to eq('https://whitey.com')
+    end
+  end
+
   describe 'shortname=' do
     context 'when the value was not blank' do
-      it 'sets the value' do
+      it 'strips whitespace before saving' do
         organiser = build(:organiser)
+        organiser.shortname = ' Whitey '
 
-        organiser.shortname = 'foo'
+        organiser.valid?
 
-        expect(organiser.shortname).to eq 'foo'
+        expect(organiser.shortname).to eq 'Whitey'
       end
     end
 

--- a/spec/models/venue_spec.rb
+++ b/spec/models/venue_spec.rb
@@ -14,6 +14,46 @@ RSpec.describe Venue do
     it { is_expected.to validate_presence_of(:name) }
   end
 
+  describe '#name' do
+    it 'strips whitespace before saving' do
+      venue = build(:venue, name: " \tThe Alhambra ")
+
+      venue.valid?
+
+      expect(venue.name).to eq('The Alhambra')
+    end
+  end
+
+  describe '#area' do
+    it 'strips whitespace before saving' do
+      venue = build(:venue, area: " \tNewington Green ")
+
+      venue.valid?
+
+      expect(venue.area).to eq('Newington Green')
+    end
+  end
+
+  describe '#postcode' do
+    it 'strips whitespace before saving' do
+      venue = build(:venue, postcode: " \tN16 9RZ ")
+
+      venue.valid?
+
+      expect(venue.postcode).to eq('N16 9RZ')
+    end
+  end
+
+  describe '#website' do
+    it 'strips whitespace before saving' do
+      venue = build(:venue, website: " \thttps://alhambra.com ")
+
+      venue.valid?
+
+      expect(venue.website).to eq('https://alhambra.com')
+    end
+  end
+
   describe 'can_delete?' do
     it 'is true if there are no associated events' do
       venue = build(:venue)


### PR DESCRIPTION
Some events with leading whitespace in the name exist in the database.
Not sure if it's actually causing any real problems, but it seems like a
good idea to prevent this.