### PR TITLE
Allow selecting no venue

### DIFF
--- a/app/javascript/application_cms.js
+++ b/app/javascript/application_cms.js
@@ -2,6 +2,8 @@ import accessibleAutocomplete from 'accessible-autocomplete'
 
 accessibleAutocomplete.enhanceSelectElement({
   selectElement: document.querySelector('#event_venue_id'),
+  defaultValue: '',
+  preserveNullOptions: true,
   showAllValues: true
 })
 accessibleAutocomplete.enhanceSelectElement({


### PR DESCRIPTION
This is the behaviour on the other dropdowns. I'm not sure why this one was different - maybe with the idea that the other two dropdowns are optional but this one is required.

But the reason for allowing blank is that if you empty the text field, then you'll implicitly be selecting the first venue in the list, which is obviously incorrect.