### PR TITLE
Remove event shortname

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -28,7 +28,7 @@ class Event < ApplicationRecord
   validate :socials_must_have_titles
   validate :will_be_listed
 
-  strip_attributes only: %i[title shortname url]
+  strip_attributes only: %i[title url]
 
   def cannot_be_weekly_and_have_dates
     return unless weekly? && !dates.empty?

--- a/db/migrate/20220928222048_remove_shortname_from_events.rb
+++ b/db/migrate/20220928222048_remove_shortname_from_events.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveShortnameFromEvents < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :events, :shortname, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_20_135448) do
+ActiveRecord::Schema.define(version: 2022_09_28_222048) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,7 +50,6 @@ ActiveRecord::Schema.define(version: 2022_05_20_135448) do
     t.string "cancellation_array", limit: 255
     t.date "first_date"
     t.date "last_date"
-    t.string "shortname", limit: 255
     t.text "class_style"
     t.integer "course_length"
     t.boolean "has_taster"

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -14,16 +14,6 @@ describe Event do
     end
   end
 
-  describe '#shortname' do
-    it 'strips whitespace before saving' do
-      event = build(:event, shortname: " \tDance! ")
-
-      event.valid?
-
-      expect(event.shortname).to eq('Dance!')
-    end
-  end
-
   describe '#url' do
     it 'strips whitespace before saving' do
       event = build(:event, url: " \thttps://dancetime.co.uk ")


### PR DESCRIPTION
This was used originally to have a quick way to find events eg. something like

events/edit/rr

...for red rhythm.

I think this was motivated by a "we have data so let's record it" kind of thinking: RR was how me and my friends would refer to this event in text.

But it hasn't been used in many years and it seems that the feature using it was removed a while back.

This is the list of shortnames at the time of removal:

[id, title, shortname]
[8, "Blitz Party", "blitz"],
[9, "Swing Pit", "pit"],
[10, "Saturday Night Swing Club", "snscfirefly"],
[14, "Rock a hula", "rockahula"],
[18, "Swing Den East (Beginner social)", "swingden"], [21, "Swing Patrol", "spoldst"],
[22, "Black Cotton Club", "blackcotton"],
[27, "Mouthful O'Jam", "mfoj"],
[33, "Book Club Blues", "bcb"],
[42, "A-Train", "atrain"],
[43, "The Swing Cellar", "swingcellar"],
[49, "Hellzapoppin", "helza"],
[50, "Gangbusters", "gb"],
[58, "Down Home Blues - VENUE CHANGE", "dhb"],
[69, "Die Freche Muse", "dfm"],
[96, "Swing Patrol", "spcamden"],
[103, "Swingout East", "swingouteast"],
[131, "Afternoon Tea Dance (Ballroom, Latin and Swing)", "ragroof"], [142, "Swing Patrol Waterloo", "spwaterloo"],
[145, "The Candlelight Club", "cc"],
[170, "Holborn Hop", "holbornhop"],
[171, "Swing Patrol", "spangel"],
[199, "The Sunday Shuffle (Balboa social) NEW VENUE", "shuffle"], [221, "The Jump Session", "jumpsession"],
[222, "Red Rhythm", "rr"],
[241, "Swing it! Rock it! Roll it!", "swingit"],
[251, "Pussyfoot", "pussyfoot"],
[260, "Suzi Q", "suziq"],
[277, "Ain't Misbehavin'", "misbehavin"],
[282, "Swing Cat's Jam", "swingcatsjam"],
[283, "After Hours", "churchill"],
[287, "Swing Patrol Pop-up Balboa", "popupbal"],
[289, "", "swinglandbrix"],
[290, "Swing at the Abbey", "thelight"],
[292, "", "spfin"],
[294, "Swing Patrol", "spstockwell"],
[295, "Swing Patrol Christmas Party", "spxmas"],
[297, "", "spputney"],
[298, "", "spstmarks"],
[302, "Swing Rendezvous (afternoon)", "swingrv"],
[318, "", "spbloomsbury"],
[320, "", "spbattersea"],
[322, "(SP Balboa)", "spbal"],
[331, "King Candy & the Sugar Push Present: Let Me Off Downtown!", "downtown"], [334, "Sin City Blues", "sincity"],
[335, "Tuesday Blues Circus", "tuesblues"],
[337, "", "spnottinghill"],
[342, "Midweek Function", "midweek"],
[353, "The Shellac Shake", "shellac"],
[354, "NW6 Swing Den (Beginner Social)", "nwsix"], [357, "Snakehip Swing (free)", "snake"],
[358, "Brew that Hop", "brew"],
[368, "The Blues Café", "bluescafe"],
[382, "Swing Joint", "swingjoint"],
[385, "Phoenix Dance Club", "phoenix"],
[398, "(This joint is) Jumpin'", "jumpin"],
[403, "Jitterbugs", "jitts"],
[404, "Bal Fridays", "balfridays"],
[412, "Minor Swing (with the Kings Cross Hot Club)", "minorswing"], [416, "Herr Kettners Kabaret", "kabaret"],
[426, "King Candy & the Sugar Push Present: Let Me Off Downtown!", "lmod"], [435, "Blues at the Ritzy", "ritzyblues"],
[437, "Saturday Night Swing Club", "snsc"],
[453, "", "spbrix"],
[455, "", "spuol"],
[510, "Club Savoy", "clubsavoy"],
[544, "Kings X Swing (Collegiate Shag social)", "kxs"], [662, "", "spsoho"],
[690, "Opus One", "opusone"],
[708, "Wireless", "wireless"],
[719, "Pink Swing (LGBT)", "pink"],
[747, "Southside Strutters", "sss"],
[779, "", "spng"],
[817, "", "spcj"],
[891, "The Broken Swing Band Presents: Swing On The Square", "sots"], [960, "Secret Late at the Horniman Museum", "hornimanlate"]