### PR TITLE
Improve dates help text

### DIFF
--- a/app/assets/stylesheets/cms/forms.scss
+++ b/app/assets/stylesheets/cms/forms.scss
@@ -35,6 +35,10 @@ form {
     color: $lowlight-colour;
   }
 
+  p.help {
+    margin-bottom: 5px;
+  }
+
   label {
     font-weight: bold;
   }

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -89,14 +89,14 @@
     <span class='help'>(For one-off or intermittent events, use 0)</span>
   </div>
   <div class='form-group'>
-    <%= f.label :date_array, 'Dates' %>
+    <%= f.label :date_array, 'Upcoming dates' %>
+    <p class='help'><%= t('forms.help.dates') %></p>
     <%= f.text_field :date_array, :value => @event.print_dates %>
-    <span class='help'>DD/MM/YYYY, separated by commas</span>
   </div>
   <div class='form-group'>
     <%= f.label :cancellation_array, 'Cancelled dates' %>
+    <p class='help'><%= t('forms.help.dates') %></p>
     <%= f.text_field :cancellation_array, :value => @event.print_cancellations %>
-    <span class='help'>DD/MM/YYYY, separated by commas</span>
   </div>
   <div class='form-group'>
     <%= f.label :first_date %>

--- a/app/views/external_events/edit.html.erb
+++ b/app/views/external_events/edit.html.erb
@@ -27,15 +27,15 @@
   </div>
 
   <div class='form-group'>
-    <%= f.label :date_array, 'Dates' %>
+    <%= f.label :date_array, 'Upcoming dates' %>
+    <p class='help'><%= t('forms.help.dates') %></p>
     <%= f.text_field :date_array, :value => @event.print_dates %>
-    <span class='help'>DD/MM/YYYY, separated by commas</span>
   </div>
 
   <div class='form-group'>
     <%= f.label :cancellation_array, 'Cancelled dates' %>
+    <p class='help'><%= t('forms.help.dates') %></p>
     <%= f.text_field :cancellation_array, :value => @event.print_cancellations %>
-    <span class='help'>DD/MM/YYYY, separated by commas</span>
   </div>
 
   <div class='form-group'>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,8 @@ en:
       days_of_week: 'We can only show you classes for days of the week'
       14_days: 'We can only show you events for the next 14 days'
   forms:
+    help:
+      dates: Enter dates separated with commas, eg. 25/6/2023,1/2/2024
     events:
       default_class_style: Lindy Hop or general swing
 

--- a/spec/system/admins_can_create_events_spec.rb
+++ b/spec/system/admins_can_create_events_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Admins can create events', :js do
     fill_in 'Course length', with: ''
     select 'Wednesday', from: 'Day'
     fill_in 'event_frequency', with: '0'
-    fill_in 'Dates', with: '12/12/2012, 19/12/2012'
+    fill_in 'Upcoming dates', with: '12/12/2012, 19/12/2012'
     # TODO: Make this work:
     # fill_in 'Cancelled dates', with: '12/12/2012'
     fill_in 'First date', with: ''

--- a/spec/system/admins_can_edit_events_spec.rb
+++ b/spec/system/admins_can_edit_events_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'Admins can edit events', :js do
     # uncheck 'Has a taster?'
     # uncheck 'Has social?'
     fill_in 'event_frequency', with: '1'
-    fill_in 'Dates', with: '12/12/2012'
+    fill_in 'Upcoming dates', with: '12/12/2012'
     fill_in 'Url', with: ''
 
     click_on 'Update'
@@ -85,7 +85,7 @@ RSpec.describe 'Admins can edit events', :js do
 
     click_on 'Edit', match: :first
 
-    fill_in 'Dates', with: '12/12/2012, 12/01/2013'
+    fill_in 'Upcoming dates', with: '12/12/2012, 12/01/2013'
 
     Timecop.freeze(Time.zone.local(2015, 1, 2, 23, 17, 16)) do
       click_on 'Update'

--- a/spec/system/organisers_can_edit_events_spec.rb
+++ b/spec/system/organisers_can_edit_events_spec.rb
@@ -22,14 +22,14 @@ RSpec.describe 'Organisers can edit events' do
         .and have_content("Day\nWednesday")
 
       select 'The 100 Club', from: 'Venue'
-      fill_in 'Dates', with: '12/12/2012, 12/01/2013'
+      fill_in 'Upcoming dates', with: '12/12/2012, 12/01/2013'
       fill_in 'Cancelled dates', with: '12/12/2012'
       fill_in 'Last date', with: '12/01/2013'
       click_on 'Update'
 
       aggregate_failures do
         expect(page).to have_select('Venue', selected: 'The 100 Club - central')
-        expect(page).to have_field('Dates', with: '12/12/2012,12/01/2013')
+        expect(page).to have_field('Upcoming dates', with: '12/12/2012,12/01/2013')
         expect(page).to have_field('Cancelled dates', with: '12/12/2012')
         expect(page).to have_field('Last date', with: '12/01/2013')
         expect(page).to have_content('Event was successfully updated')

--- a/spec/system/smoke_spec.rb
+++ b/spec/system/smoke_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Adding a new event' do
     fill_in 'Course length', with: ''
     select 'Saturday', from: 'Day'
     fill_in 'event_frequency', with: 1
-    fill_in 'Dates', with: ''
+    fill_in 'Upcoming dates', with: ''
     fill_in 'Cancelled dates', with: '11/10/1958'
     fill_in 'First date', with: '12/03/1926'
     fill_in 'Next expected', with: ''


### PR DESCRIPTION
:pushpin: https://trello.com/c/ybXdPkGf/72-change-hint-text-on-date-entry-fields-to-reduce-chance-of-user-misunderstanding-include-example

Change hint text on date entry fields to reduce chance of user
misunderstanding, include example

Users on the new edit link may not understand the dates field, although
the hint text already explains the date formatting a worked example
might be easier. We can't afford to have the listing/site break because
they've put some nonsense in this field, so it reduces the risk.