### PR TITLE
Enforce that classes have organisers

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -26,6 +26,7 @@ class Event < ApplicationRecord
 
   validate :cannot_be_weekly_and_have_dates
   validate :socials_must_have_titles
+  validate :classes_must_have_organisers
   validate :will_be_listed
 
   strip_attributes only: %i[title url]
@@ -47,6 +48,12 @@ class Event < ApplicationRecord
     return if title.present?
 
     errors.add(:title, 'must be present for social dances')
+  end
+
+  def classes_must_have_organisers
+    return unless has_class? && class_organiser_id.nil?
+
+    errors.add(:class_organiser_id, 'must be present for classes')
   end
 
   # display constants:

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -22,6 +22,7 @@ FactoryBot.define do
       frequency { 1 }
       # generate classes for different days of the week:
       sequence(:day) { |wd| Date::DAYNAMES[wd % 7] }
+      class_organiser factory: :organiser
     end
 
     factory :weekly_social do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -339,7 +339,7 @@ describe Event do
     end
 
     it 'is valid if it has a class but no taster or social (and everything else is OK)' do
-      expect(build(:event, has_taster: false, has_social: false, has_class: true)).to be_valid
+      expect(build(:event, has_taster: false, has_social: false, has_class: true, class_organiser_id: 7)).to be_valid
     end
 
     it 'is valid if it has a social but no taster or class (and everything else is OK)' do
@@ -353,16 +353,22 @@ describe Event do
     end
 
     it "is valid if it's a class without a title" do
-      expect(build(:event, has_taster: false, has_social: false, has_class: true, title: nil)).to be_valid
+      expect(build(:event, has_taster: false, has_social: false, has_class: true, title: nil, class_organiser_id: 7)).to be_valid
     end
 
     it "is invalid if it's a social without a title" do
-      event = build(:event, has_taster: false, has_social: true, has_class: true, title: nil)
+      event = build(:event, has_taster: false, has_social: true, has_class: false, title: nil)
       event.valid?
       expect(event.errors.messages).to eq(title: ['must be present for social dances'])
     end
 
     it { is_expected.to validate_uniqueness_of(:organiser_token).allow_nil }
+
+    it "is invalid if it has a class and doesn't have a class organiser" do
+      event = build(:event, has_taster: false, has_social: false, has_class: true, class_organiser: nil)
+      event.valid?
+      expect(event.errors.messages).to eq(class_organiser_id: ['must be present for classes'])
+    end
   end
 
   describe 'expected_date' do

--- a/spec/system/admins_can_edit_events_spec.rb
+++ b/spec/system/admins_can_edit_events_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'Admins can edit events', :js do
 
   it 'with invalid data' do
     stub_login(id: 12345678901234567, name: 'Al Minns')
-    create(:event, has_class: true)
+    create(:class)
 
     visit '/login'
     click_on 'Log in with Facebook'


### PR DESCRIPTION
We're expecting this to be the case in several places in order to
display classes with some information - otherwise there's really nothing
to identify them apart from the location.