### PR TITLE
Add "Frequency" to external events page

### DIFF
--- a/app/views/external_events/edit.html.erb
+++ b/app/views/external_events/edit.html.erb
@@ -22,15 +22,21 @@
   </div>
 
   <div class='form-group'>
-    <label>Day</label>
-    <p><%= @event.day %></p>
+    <label>Frequency</label>
+    <% if @event.weekly? %>
+      <p>Every <%= @event.day %></p>
+    <% else %>
+      <p>Occasional</p>
+    <% end %>
   </div>
 
-  <div class='form-group'>
-    <%= f.label :date_array, 'Upcoming dates' %>
-    <p class='help'><%= t('forms.help.dates') %></p>
-    <%= f.text_field :date_array, :value => @event.print_dates %>
-  </div>
+  <% unless @event.weekly? %>
+    <div class='form-group'>
+      <%= f.label :date_array, 'Upcoming dates' %>
+      <p class='help'><%= t('forms.help.dates') %></p>
+      <%= f.text_field :date_array, :value => @event.print_dates %>
+    </div>
+  <% end %>
 
   <div class='form-group'>
     <%= f.label :cancellation_array, 'Cancelled dates' %>

--- a/app/views/external_events/edit.html.erb
+++ b/app/views/external_events/edit.html.erb
@@ -17,13 +17,13 @@
   </div>
 
   <div class='form-group'>
-    <label>Day</label>
-    <p><%= @event.day %></p>
+    <%= f.label :venue_id, 'Venue' %>
+    <%= f.select :venue_id, venue_select, {:include_blank => true} %>
   </div>
 
   <div class='form-group'>
-    <%= f.label :venue_id, 'Venue' %>
-    <%= f.select :venue_id, venue_select, {:include_blank => true} %>
+    <label>Day</label>
+    <p><%= @event.day %></p>
   </div>
 
   <div class='form-group'>

--- a/spec/system/organisers_can_edit_events_spec.rb
+++ b/spec/system/organisers_can_edit_events_spec.rb
@@ -4,13 +4,13 @@ require 'rails_helper'
 
 RSpec.describe 'Organisers can edit events' do
   context 'when an organiser token exists' do
-    it 'allows an organiser to edit an event' do
+    it 'allows an organiser to edit an occasional event' do
       create(
         :social,
         organiser_token: 'abc123',
         title: 'Midtown stomp',
         url: 'https://www.swingland.com/midtown',
-        day: 'Wednesday',
+        frequency: 0,
         first_date: Date.new(2001, 2, 3)
       )
       create(:venue, name: 'The 100 Club', area: 'central')
@@ -19,7 +19,7 @@ RSpec.describe 'Organisers can edit events' do
 
       expect(page).to have_content('Midtown stomp')
         .and have_link('https://www.swingland.com/midtown', href: 'https://www.swingland.com/midtown')
-        .and have_content("Day\nWednesday")
+        .and have_content("Frequency\nOccasional")
 
       select 'The 100 Club', from: 'Venue'
       fill_in 'Upcoming dates', with: '12/12/2012, 12/01/2013'
@@ -30,6 +30,41 @@ RSpec.describe 'Organisers can edit events' do
       aggregate_failures do
         expect(page).to have_select('Venue', selected: 'The 100 Club - central')
         expect(page).to have_field('Upcoming dates', with: '12/12/2012,12/01/2013')
+        expect(page).to have_field('Cancelled dates', with: '12/12/2012')
+        expect(page).to have_field('Last date', with: '12/01/2013')
+        expect(page).to have_content('Event was successfully updated')
+      end
+
+      expect(Audit.last.username).to eq('name' => 'Organiser (abc123)', 'auth_id' => 'abc123')
+    end
+
+    it 'allows an organiser to edit a weekly event' do
+      create(
+        :social,
+        organiser_token: 'abc123',
+        title: 'Midtown stomp',
+        url: 'https://www.swingland.com/midtown',
+        day: 'Wednesday',
+        frequency: 1,
+        first_date: Date.new(2001, 2, 3)
+      )
+      create(:venue, name: 'The 100 Club', area: 'central')
+
+      visit('/external_events/abc123/edit')
+
+      expect(page).to have_content('Midtown stomp')
+        .and have_link('https://www.swingland.com/midtown', href: 'https://www.swingland.com/midtown')
+        .and have_content("Frequency\nEvery Wednesday")
+      expect(page).not_to have_content('Upcoming dates')
+
+      select 'The 100 Club', from: 'Venue'
+      fill_in 'Cancelled dates', with: '12/12/2012'
+      fill_in 'Last date', with: '12/01/2013'
+      click_on 'Update'
+
+      aggregate_failures do
+        expect(page).to have_select('Venue', selected: 'The 100 Club - central')
+        expect(page).not_to have_content('Upcoming dates')
         expect(page).to have_field('Cancelled dates', with: '12/12/2012')
         expect(page).to have_field('Last date', with: '12/01/2013')
         expect(page).to have_content('Event was successfully updated')


### PR DESCRIPTION
We're settling on events being pretty much weekly or occasional - so let's
reflect that here.

Weekly events shouldn't have a dates box, since they can't use it anyway.