### PR TITLE
Add a cancel button for external events

### DIFF
--- a/app/views/external_events/edit.html.erb
+++ b/app/views/external_events/edit.html.erb
@@ -52,5 +52,6 @@
 
   <div class='form-group actions'>
     <%= f.submit 'Update', class: 'button' %>
+    <%= link_to 'Cancel', edit_external_event_path(@event.organiser_token), class: "button button-secondary" %>
   </div>
 <% end %>


### PR DESCRIPTION
So that organisers can undo any changes if they messed up before hitting
update.

Just reloads the page.