### PR TITLE
Remove Map flash

### DIFF
--- a/app/assets/stylesheets/website/map.scss
+++ b/app/assets/stylesheets/website/map.scss
@@ -109,12 +109,6 @@ body.socials {
     }
   }
 
-  .banner {
-    background-color: $banner-colour;
-    padding: 5px;
-    font-size: 90%;
-  }
-
   .listings {
     box-shadow: 9px 9px 12px rgba(50, 50, 50, 0.75), inset 0 18px 20px -20px rgba(50, 50, 50, 0.75);
 

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -28,7 +28,6 @@ class MapsController < ApplicationController
         renderer: self
       )
   rescue Maps::Classes::DayParser::NonDayError
-    flash[:warn] = t("flash.map.days_of_week")
     logger.warn("Not a recognised day: #{@day}")
     redirect_to map_classes_path
   end
@@ -52,7 +51,6 @@ class MapsController < ApplicationController
         renderer: self
       )
   rescue Maps::Socials::Dates::DateOutOfRangeError
-    flash[:warn] = t("flash.map.14_days")
     logger.warn("Not a date in the visible range: #{@date}")
     redirect_to map_socials_path
   end

--- a/app/views/maps/classes.html.haml
+++ b/app/views/maps/classes.html.haml
@@ -12,9 +12,6 @@
 
 - content_for :listings do
   %ul
-    - if flash.any?
-      - flash.each do |_level, message|
-        %li.banner= message
     - DAYNAMES.each do |day|
       %li
         = link_to day.pluralize, { day: day }, { class: ["js-update-map", (:selected if day == @day)], data: { url: map_classes_path(day, format: :json) } }

--- a/app/views/maps/socials.html.erb
+++ b/app/views/maps/socials.html.erb
@@ -20,14 +20,6 @@
 
 <% content_for :listings do %>
   <ul>
-    <% if flash.any? %>
-      <% flash.each do |_level, message| %>
-        <li class="banner">
-          <%= message %>
-        </li>
-      <% end %>
-    <% end %>
-
     <% @map_dates.listing_dates.each do |date| %>
       <li>
         <%= link_to date.to_s(:listing_date), { date: date.to_s(:db) }, { class: ["js-update-map", (:selected if date == @map_dates.selected_date)], data: { url: map_socials_path(date, format: :json) } } %>

--- a/spec/controllers/maps_controller_spec.rb
+++ b/spec/controllers/maps_controller_spec.rb
@@ -24,11 +24,6 @@ describe MapsController do
         it "redirects to the main classes page" do
           expect(get(:classes, params: { day: "fuseday" })).to redirect_to("/map/classes")
         end
-
-        it "shows a flash message" do
-          get :classes, params: { day: "fuseday" }
-          expect(flash[:warn]).to eq "We can only show you classes for days of the week"
-        end
       end
 
       context "when the day is described in words" do
@@ -49,11 +44,6 @@ describe MapsController do
         context "the url contained 'yesterday'" do
           it "redirects to the main classes page" do
             expect(get(:classes, params: { day: "yesterday" })).to redirect_to("/map/classes")
-          end
-
-          it "shows a flash message" do
-            get :classes, params: { day: "fuseday" }
-            expect(flash[:warn]).to eq "We can only show you classes for days of the week"
           end
         end
       end
@@ -94,11 +84,6 @@ describe MapsController do
       context "when the url string doesn't represent a date" do
         it "redirects to the main socials page" do
           expect(get(:socials, params: { date: "asfasfasf" })).to redirect_to("/map/socials")
-        end
-
-        it "shows a flash message" do
-          get :socials, params: { date: "asfasfasf" }
-          expect(flash[:warn]).to eq "We can only show you events for the next 14 days"
         end
       end
     end

--- a/spec/system/users_can_see_a_map_spec.rb
+++ b/spec/system/users_can_see_a_map_spec.rb
@@ -50,12 +50,14 @@ RSpec.describe "Users can view a map of upcoming events" do
       expect(info_window).to have_link("Bedroom Bounce", href: "https://bb.com")
     end
 
-    it "looking at a date in the past" do
-      visit "/map/socials/2015-12-25"
+    context "when a date in the past is requested" do
+      it "redirects to the main socials view" do
+        visit "/map/socials/2015-12-25"
 
-      expect(page).to have_content("Swing Out London")
-      expect(page).to have_content("Lindy Map")
-      expect(page).to have_content("We can only show you events for the next 14 days")
+        expect(page).to have_content("Swing Out London")
+        expect(page).to have_content("Lindy Map")
+        expect(page).to have_current_path("/map/socials")
+      end
     end
 
     context "when a social has no title (regression test)" do
@@ -113,12 +115,14 @@ RSpec.describe "Users can view a map of upcoming events" do
       expect(info_window).to have_link("Class (Balboa) with Morning Swing", href: "https://dlc.com")
     end
 
-    it "looking at a misspelled day" do
-      visit "/map/classes/mOoonday"
+    context "when the day is misspelled" do
+      it "redirects to the main classes view" do
+        visit "/map/classes/mOoonday"
 
-      expect(page).to have_content("Swing Out London")
-      expect(page).to have_content("Lindy Map")
-      expect(page).to have_content("We can only show you classes for days of the week")
+        expect(page).to have_content("Swing Out London")
+        expect(page).to have_content("Lindy Map")
+        expect(page).to have_current_path("/map/classes")
+      end
     end
   end
 end


### PR DESCRIPTION
The idea originally was to show a message to users who followed links to old dates or days, explaining why we can't show that date.

This fundamentally doesn't work since the page is cached, so in the scenario where an admin makes an update which results in a flash message about eg. a venue being updated, then visits the map and gets a fresh page, then that flash message gets cached for any users viewing the page after them.