### PR TITLE
Show dates or day based on frequency

### DIFF
--- a/app/assets/stylesheets/cms/forms.scss
+++ b/app/assets/stylesheets/cms/forms.scss
@@ -108,13 +108,12 @@ form.edit_venue {
     margin: 3px 0 5px;
   }
 
-  .form-group,
-  .form-subgroup {
+  .form-group {
     margin-bottom: 15px;
   }
 
   label,
-  .form-subgroup-title {
+  .form-group-title {
     font-size: 16px;
     font-family: sans-serif;
     font-weight: bold;

--- a/app/assets/stylesheets/cms/forms.scss
+++ b/app/assets/stylesheets/cms/forms.scss
@@ -5,12 +5,6 @@ form {
     margin-bottom: 0.5em;
   }
 
-  .form-group-title {
-    font-size: 20px;
-    margin-top: 20px;
-    margin-bottom: 5px;
-  }
-
   .form-group-nested {
     margin-left: 25px;
 
@@ -109,13 +103,14 @@ form.edit_venue {
     }
   }
 
+  .form-section-title {
+    font-size: 20px;
+    margin: 3px 0 5px;
+  }
+
   .form-group,
   .form-subgroup {
     margin-bottom: 15px;
-  }
-
-  .form-group-title {
-    margin: 3px 0 5px;
   }
 
   label,

--- a/app/javascript/controllers/event_frequency_controller.js
+++ b/app/javascript/controllers/event_frequency_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="event-frequency"
+export default class extends Controller {
+  static targets = [ "daySelect", "datesInput" ]
+  static classes = [ "hidden" ]
+
+  setWeekly() {
+    this.daySelectTarget.classList.remove(this.hiddenClass);
+    this.datesInputTarget.classList.add(this.hiddenClass);
+    this.datesInputTarget.querySelectorAll('input').forEach(el => { el.value = "" })
+  }
+
+  setInfrequently() {
+    this.daySelectTarget.classList.add(this.hiddenClass);
+    this.datesInputTarget.classList.remove(this.hiddenClass);
+    this.daySelectTarget.querySelectorAll('select').forEach(el => { el.selectedIndex = null })
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,5 +4,8 @@
 
 import { application } from "./application"
 
+import EventFrequencyController from "./event_frequency_controller"
+application.register("event-frequency", EventFrequencyController)
+
 import OrganiserLinkController from "./organiser_link_controller"
 application.register("organiser-link", OrganiserLinkController)

--- a/app/presenters/show_event.rb
+++ b/app/presenters/show_event.rb
@@ -44,8 +44,8 @@ class ShowEvent
 
   def frequency # rubocop:disable Metrics/MethodLength
     case event.frequency
-    when 0 then "One-off or intermittent"
-    when 1 then "Weekly"
+    when 0 then "Monthly or occasionally"
+    when 1 then "Weekly on #{event.day.pluralize}"
     when 2 then "Fortnightly"
     when 4..5 then "Monthly"
     when 8 then "Bi-Monthly"

--- a/app/views/events/_event_listing_table_row.html.erb
+++ b/app/views/events/_event_listing_table_row.html.erb
@@ -18,9 +18,6 @@
     <td class="soc_org">
       <%= organiser_link(event.social_organiser) %>
     </td>
-    <td class="day">
-      <%= event.day[0..2] %>
-    </td>
     <td class="fq center">
       <%= event.frequency %>
     </td>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -12,7 +12,7 @@
       <%= f.select :venue_id, venue_select, {:include_blank => true} %>
     </div>
     <div class='form-group'>
-      <h4 class="form-subgroup-title">Event Type</h4>
+      <h4 class="form-group-title">Event Type</h4>
 
       <% event_type_select.each do |description, help, value| %>
         <label>
@@ -63,8 +63,8 @@
       <p class='help'>The location and organiser name are displayed in the listings.</>
     </div>
 
-    <h4 class='form-subgroup-title'>Class style</h3>
-    <div class='form-subgroup' id="class-style-selection">
+    <div class='form-group' id="class-style-selection">
+      <h4 class='form-group-title'>Class style</h3>
       <div class='radio-group'>
         <%= radio_button_tag 'class_style_option', 'lindy', @event.class_style.blank? %>
         <%= label_tag :class_style_option_lindy, t('forms.events.default_class_style') %>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -84,18 +84,27 @@
     </div>
   </section>
 
-  <section>
+  <section data-controller="event-frequency" data-event-frequency-hidden-class="hidden">
     <h3 class='form-section-title'>When?</h3>
     <div class='form-group'>
+      <h4 class="form-group-title">Frequency</h4>
+      <label>
+        <%= f.radio_button(:frequency, 1, data: { action: "event-frequency#setWeekly" }) %>
+        Weekly
+      </label>
+      <label>
+        <%= f.radio_button(:frequency, 0, data: { action: "event-frequency#setInfrequently" }) %>
+        Monthly or occasionally
+      </label>
+      <% unless [0, 1].include?(@event.frequency) %>
+        <p class="help">Legacy frequency: <%= @event.frequency %></p>
+      <% end %>
+    </div>
+    <div class='form-group <%= "hidden" unless @event.weekly? %>' data-event-frequency-target="daySelect">
       <%= f.label :day %>
-      <%= f.select :day, DAYNAMES %>
+      <%= f.select :day, DAYNAMES, include_blank: true %>
     </div>
-    <div class='form-group'>
-      <%= f.label :frequency %>
-      <p class='help'>For one-off or intermittent events, use 0</p>
-      every <%= f.text_field :frequency, :size => 2, :class =>"shortfield" %> weeks
-    </div>
-    <div class='form-group'>
+    <div class='form-group <%= "hidden" unless @event.infrequent? %>' data-event-frequency-target="datesInput">
       <%= f.label :date_array, 'Upcoming dates' %>
       <p class='help'><%= t('forms.help.dates') %></p>
       <%= f.text_field :date_array, :value => @event.print_dates %>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -29,7 +29,7 @@
   <% end %>
 
   <section>
-    <h3 class='form-group-title'>Social details</h3>
+    <h3 class='form-section-title'>Social details</h3>
     <div class='form-group'>
       <%= f.label :has_social, "Has social?" %>
       <%= f.check_box :has_social  %>
@@ -46,7 +46,7 @@
   </section>
 
   <section>
-    <h3 class='form-group-title'>Class details</h3>
+    <h3 class='form-section-title'>Class details</h3>
     <div class='form-group'>
       <%= f.label :has_class, "Has a class?" %>
       <%= f.check_box :has_class  %>
@@ -85,7 +85,7 @@
   </section>
 
   <section>
-    <h3 class='form-group-title'>When?</h3>
+    <h3 class='form-section-title'>When?</h3>
     <div class='form-group'>
       <%= f.label :day %>
       <%= f.select :day, DAYNAMES %>

--- a/app/views/events/_organiser_link.html.erb
+++ b/app/views/events/_organiser_link.html.erb
@@ -1,5 +1,5 @@
 <section data-controller="organiser-link">
-  <h3 class='form-group-title'><label for="organiser_link_url">Organiser edit link<label></h3>
+  <h3 class='form-section-title'><label for="organiser_link_url">Organiser edit link<label></h3>
   <turbo-frame id="organiser_link">
     <% if event.organiser_token %>
       <input id="organiser_link_url" type="text" value="<%= edit_external_event_url(event.organiser_token) %>" data-organiser-link-target="source" readonly><!--

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -11,7 +11,6 @@
       <th class="area">Area</th>
       <th class="class_org">Class Organiser</th>
       <th class="soc_org">Social Organiser</th>
-      <th class="day">Day</th>
       <th class="fq">Fq.</th>
       <th class="dates">Dates</th>
       <th class="updated">Last updated</th>

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -29,9 +29,6 @@
     %span Class style:
     = @event.class_style.presence || t('forms.events.default_class_style')
   %li
-    %span Day:
-    = @event.day
-  %li
     %span Frequency:
     = @event.frequency
   - unless @event.weekly?

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -10,7 +10,6 @@ FactoryBot.define do
     has_social { true }
     event_type { "school" }
     frequency { 0 }
-    day { "Monday" }
     url { Faker::Internet.url }
 
     venue

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -260,6 +260,22 @@ describe Event do
       expect(event.errors.messages).to eq(title: ["must be present for social dances"])
     end
 
+    it "is invalid if it's weekly and has no day" do
+      event = build(:event, frequency: 1, day: nil)
+      event.valid?
+      expect(event.errors.messages).to eq(day: ["must be present for weekly events"])
+    end
+
+    it "is valid if it's occasional and has no day" do
+      expect(build(:event, frequency: 0, day: nil)).to be_valid
+    end
+
+    it "is invalid without a frequency" do
+      event = build(:event, frequency: nil, day: nil)
+      event.valid?
+      expect(event.errors.messages).to eq(frequency: ["can't be blank"])
+    end
+
     it { is_expected.to validate_uniqueness_of(:organiser_token).allow_nil }
 
     it "is invalid if it has a class and doesn't have a class organiser" do
@@ -310,7 +326,7 @@ describe Event do
 
     context "when the event is weekly" do
       it "is true" do
-        event = create(:event, frequency: 1, dates: [])
+        event = create(:weekly_social)
 
         expect(event.future_dates?).to be true
       end

--- a/spec/presenters/show_event_spec.rb
+++ b/spec/presenters/show_event_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 require "active_support/core_ext/module/delegation"
 require "spec/support/time_formats_helper"
 require "app/presenters/show_event"
+require "app/presenters/date_printer"
 
 RSpec.describe ShowEvent do
   describe "#anchor" do
@@ -135,8 +136,7 @@ RSpec.describe ShowEvent do
   describe "#frequency" do
     examples = [
       { frequency: nil, text: "Unknown" },
-      { frequency: 0, text: "One-off or intermittent" },
-      { frequency: 1, text: "Weekly" },
+      { frequency: 0, text: "Monthly or occasionally" },
       { frequency: 2, text: "Fortnightly" },
       { frequency: 4, text: "Monthly" },
       { frequency: 4, text: "Monthly" },
@@ -151,6 +151,14 @@ RSpec.describe ShowEvent do
         event = instance_double("Event", frequency: example[:frequency])
 
         expect(described_class.new(event).frequency).to eq example[:text]
+      end
+    end
+
+    context "when the event is weekly" do
+      it "includes the day" do
+        event = instance_double("Event", frequency: 1, day: "Wednesday")
+
+        expect(described_class.new(event).frequency).to eq "Weekly on Wednesdays"
       end
     end
   end

--- a/spec/system/admins_can_create_events_spec.rb
+++ b/spec/system/admins_can_create_events_spec.rb
@@ -23,8 +23,9 @@ RSpec.describe "Admins can create events", :js do
     choose "Other (balboa, shag etc)"
     fill_in "Dance style", with: "Balboa"
     fill_in "Course length", with: ""
+    select "Weekly"
     select "Wednesday", from: "Day"
-    fill_in "event_frequency", with: "0"
+    select "Occasionally"
     fill_in "Upcoming dates", with: "12/12/2012, 19/12/2012"
     # TODO: Make this work:
     # fill_in 'Cancelled dates', with: '12/12/2012'
@@ -73,7 +74,7 @@ RSpec.describe "Admins can create events", :js do
     choose "School" # Event Type
     check "Has social?"
     fill_in "Title", with: "Stompin'"
-    fill_in "event_frequency", with: "1"
+    select "Weekly"
     fill_in "Url", with: "http://www.lsds.co.uk/stompin"
 
     click_on "Create"

--- a/spec/system/admins_can_create_events_spec.rb
+++ b/spec/system/admins_can_create_events_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe "Admins can create events", :js do
     choose "Other (balboa, shag etc)"
     fill_in "Dance style", with: "Balboa"
     fill_in "Course length", with: ""
-    select "Weekly"
+    choose "Weekly"
     select "Wednesday", from: "Day"
-    select "Occasionally"
+    choose "Monthly or occasionally"
     fill_in "Upcoming dates", with: "12/12/2012, 19/12/2012"
     # TODO: Make this work:
     # fill_in 'Cancelled dates', with: '12/12/2012'
@@ -42,8 +42,7 @@ RSpec.describe "Admins can create events", :js do
       .and have_content("Class Organiser:\nThe London Swing Dance Society")
       .and have_content("School, with social and taster")
       .and have_content("Class style:\nBalboa")
-      .and have_content("Day:\nWednesday")
-      .and have_content("Frequency:\nOne-off or intermittent")
+      .and have_content("Frequency:\nMonthly or occasionally")
       .and have_content("Dates:\n12/12/2012, 19/12/2012")
       .and have_content("Cancelled:\nNone")
       .and have_content("First date:")
@@ -74,14 +73,15 @@ RSpec.describe "Admins can create events", :js do
     choose "School" # Event Type
     check "Has social?"
     fill_in "Title", with: "Stompin'"
-    select "Weekly"
+    choose "Weekly"
+    select "Tuesday", from: "Day"
     fill_in "Url", with: "http://www.lsds.co.uk/stompin"
 
     click_on "Create"
 
     expect(page).to have_content("Venue:\nThe 100 Club")
       .and have_content("School, with social")
-      .and have_content("Frequency:\nWeekly")
+      .and have_content("Frequency:\nWeekly on Tuesdays")
       .and have_content("Url:\nhttp://www.lsds.co.uk/stompin")
   end
 end

--- a/spec/system/admins_can_edit_events_spec.rb
+++ b/spec/system/admins_can_edit_events_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe "Admins can edit events", :js do
   it "with valid data" do
     stub_login(id: 12345678901234567, name: "Al Minns")
-    create(:event, event_type: "dance_club", class_style: "Balboa")
+    create(:weekly_social, event_type: "dance_club", class_style: "Balboa")
     create(:venue, name: "The 100 Club")
     create(:organiser, name: "The London Swing Dance Society")
 
@@ -23,8 +23,7 @@ RSpec.describe "Admins can edit events", :js do
     check "Has social?"
     choose "Lindy Hop or general swing"
     fill_in "Course length", with: ""
-    select "Wednesday", from: "Day"
-    fill_in "event_frequency", with: "0"
+    choose "Monthly or occasionally"
     fill_in "First date", with: ""
     fill_in "Url", with: "http://www.lsds.co.uk/stompin"
 
@@ -38,8 +37,7 @@ RSpec.describe "Admins can edit events", :js do
       .and have_content("Class Organiser:\nThe London Swing Dance Society")
       .and have_content("School, with social and taster")
       .and have_content("Class style:\nLindy Hop or general swing")
-      .and have_content("Day:\nWednesday")
-      .and have_content("Frequency:\nOne-off or intermittent")
+      .and have_content("Frequency:\nMonthly or occasionally")
       .and have_content("First date:")
       .and have_content("Url:\nhttp://www.lsds.co.uk/stompin")
 
@@ -60,21 +58,20 @@ RSpec.describe "Admins can edit events", :js do
     # uncheck 'Has a class?'
     # uncheck 'Has a taster?'
     # uncheck 'Has social?'
-    fill_in "event_frequency", with: "1"
-    fill_in "Upcoming dates", with: "12/12/2012"
+    select "", from: "Day"
     fill_in "Url", with: ""
 
     click_on "Update"
 
     expect(page).to have_content("2 errors prevented this record from being saved:")
       .and have_content("Url can't be blank")
-      .and have_content("Date array must be empty for weekly events")
+      .and have_content("Day must be present for weekly events")
     # can't uncheck the relevant checkboxes in selenium chrome headless??:
     # .and have_content("Events must have either a Social or a Class, otherwise they won't be listed!")
   end
 
   it "adding dates" do
-    create(:event, dates: ["12/12/2012", "13/12/2012"])
+    create(:event, frequency: 0, dates: ["12/12/2012", "13/12/2012"])
     stub_login(id: 12345678901234567, name: "Al Minns")
 
     visit "/login"
@@ -111,5 +108,16 @@ RSpec.describe "Admins can edit events", :js do
     expect(page).to have_content("Cancelled:\n12/12/2012")
 
     expect(page).to have_content("Last updated by Al Minns (12345678901234567) on Friday 2nd January 2015 at 23:17:16")
+  end
+
+  context "when the event has an old frequency" do
+    it "shows a message" do
+      event = create(:event, frequency: 4)
+      skip_login
+
+      visit edit_event_path(event)
+
+      expect(page).to have_content("Legacy frequency: 4")
+    end
   end
 end

--- a/spec/system/admins_can_list_events_spec.rb
+++ b/spec/system/admins_can_list_events_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe "Admins can list events" do
   include ActiveSupport::Testing::TimeHelpers
 
   it "shows a list of events" do
-    # stub_login(id: 12345678901234567, name: 'Al Minns')
-
     Timecop.freeze(Time.zone.local(1997, 5, 23)) do
       create(
         :event,
@@ -15,7 +13,6 @@ RSpec.describe "Admins can list events" do
         venue: create(:venue, name: "The 100 Club", area: "Oxford Street"),
         class_organiser: create(:organiser, name: "Simon Selmon"),
         social_organiser: create(:organiser, name: "The London Swing Dance Society"),
-        day: "Monday",
         frequency: 0,
         dates: [Date.new(1997, 6, 1), Date.new(1997, 7, 5)]
       )
@@ -29,7 +26,6 @@ RSpec.describe "Admins can list events" do
       .and have_content("Oxford Street")
       .and have_content("Simon Selmon")
       .and have_content("The London Swing Dance Society")
-      .and have_content("Mon")
       .and have_content(0)
       .and have_content("05/07/1997, 01/06/1997")
   end
@@ -37,8 +33,7 @@ RSpec.describe "Admins can list events" do
   it "notes when an event has ended" do
     travel_to("20th May 1935".to_date)
     create(
-      :event,
-      frequency: 1,
+      :weekly_social,
       last_date: "1st May 1935".to_date
     )
 

--- a/spec/system/smoke_spec.rb
+++ b/spec/system/smoke_spec.rb
@@ -48,8 +48,8 @@ RSpec.describe "Adding a new event" do
     check "Has social?"
     fill_in "Dance style", with: "Savoy Style"
     fill_in "Course length", with: ""
+    choose "Weekly"
     select "Saturday", from: "Day"
-    fill_in "event_frequency", with: 1
     fill_in "Upcoming dates", with: ""
     fill_in "Cancelled dates", with: "09/01/1937"
     fill_in "First date", with: "12/03/1926"


### PR DESCRIPTION
We've decided to switch to only tracking frequency as being weekly or 
non-weekly, since this is the only distinction which is actually used.

Show/hide the date or day fields appropriately and add some validations to
make sure we still have data integrity.