### PR TITLE
Set cache headers on assets

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
     <meta content="<%= content_for?(:description) ? yield(:description) : "Swing Out London is a listing of weekly Lindy Hop classes, regular socials, swing gigs and vintage clubs" %>" name="description"/>
     <link href="humans.txt" rel="author"></link>
     <%= csrf_meta_tag %>
-    <%= javascript_include_tag :application %>
+    <%= javascript_include_tag :application, defer: true %>
     <%= stylesheet_link_tag 'application', media: "screen" %>
     <meta content="none" name="msapplication-config"/>
     <%= yield :head %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,6 +23,9 @@ Rails.application.configure do
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.headers = {
+    "Cache-Control" => "public, max-age=31536000, immutable"
+  }
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass


### PR DESCRIPTION
public_file_server is supposed to be for development (serve assets from
the /public directory) but for some reason heroku has
RAILS_SERVE_STATIC_FILES on:

  https://devcenter.heroku.com/changelog-items/617

Which is... whatever, but has the result of not setting any cache
headers. Google lighthouse complains about this, though my browser seems
to be always loading them from disk anyway.

These headers are the visible on assets run locally (where
RAILS_SERVE_STATIC_FILES is false).