### PR TITLE
Use GA4 analytics link click tracking

### DIFF
--- a/app/javascript/application/listing.js
+++ b/app/javascript/application/listing.js
@@ -13,36 +13,6 @@ export function initListings() {
   }
 };
 
-function add_socials_analytics_events() {
-  return document.querySelector('#social_dances .datelist .details a').addEventListener("click", () => {
-    return _gaq.push(['_trackEvent', 'Social Link', '#' + this.id, this.text]);
-  });
-};
-
-function add_advertisement_analytics_events() {
-  return document.querySelector('#advert a').addEventListener("click", () => {
-    return _gaq.push(['_trackEvent', 'Advert Link', this.id, this.href]);
-  });
-};
-
-function add_donation_button_analytics_event() {
-  return document.querySelector('.donate_button').addEventListener("click", () => {
-    return _gaq.push(['_trackEvent', 'Donate Button', 'donate_button', this.href]);
-  });
-};
-
-function add_tweet_share_analytics_event() {
-  return document.querySelector('.share_button.twitter').addEventListener("click", () => {
-    return _gaq.push(['_trackEvent', 'Share Button', 'twitter', this.href]);
-  });
-};
-
-function add_facebook_share_analytics_event() {
-  return document.querySelector('.share_button.facebook').addEventListener("click", () => {
-    return _gaq.push(['_trackEvent', 'Share Button', 'facebook', this.href]);
-  });
-};
-
 function add_facebook_share_click_handler() {
   var height, left, other_options, share_link, size_and_position, top, url, width;
   share_link = document.querySelector(".share_button.facebook");

--- a/app/views/listings/_advert.html.erb
+++ b/app/views/listings/_advert.html.erb
@@ -1,6 +1,6 @@
 <aside id="advert">
   <% if advert %>
-    <%= link_to advert.url, title: advert.title, id: advert.google_id do %>
+    <%= link_to advert.url, title: advert.title, class: ["ga-advert", advert.google_id] do %>
       <%= image_tag advert.image_url, alt: "Advertisment: #{advert.title}" %>
     <% end %>
   <% else %>

--- a/app/views/listings/_advert.html.erb
+++ b/app/views/listings/_advert.html.erb
@@ -1,0 +1,11 @@
+<aside id="advert">
+  <% if advert %>
+    <%= link_to advert.url, title: advert.title, id: advert.google_id do %>
+      <%= image_tag advert.image_url, alt: "Advertisment: #{advert.title}" %>
+    <% end %>
+  <% else %>
+    <div class="text">
+      <%= mail_to "swingoutlondon@gmail.com", "Advertise here" %>
+    </div>
+  <% end %>
+</aside>

--- a/app/views/listings/_advert.html.haml
+++ b/app/views/listings/_advert.html.haml
@@ -1,7 +1,0 @@
-%aside#advert
-  - if advert
-    = link_to advert.url, title: advert.title, id: advert.google_id do
-      = image_tag advert.image_url, alt: "Advertisment: #{advert.title}"
-  - else
-    .text
-      = mail_to "swingoutlondon@gmail.com", "Advertise here"

--- a/spec/system/users_can_see_adverts_spec.rb
+++ b/spec/system/users_can_see_adverts_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Users can see adverts" do
       nil,
       href: "https://myevent.co.uk",
       title: "My Event",
-      id: "me-1"
+      class: "ga-advert me-1"
     )
     expect(page).to have_xpath("//img[@src = 'https://myevent.co.uk/banner' and @alt = 'Advertisment: My Event']")
   end


### PR DESCRIPTION
With Google Analytics 4, most link clicks are tracked automatically, so we
don't need to attach events manually.

These `_gaq.push` things are no longer supported - we get errors when these
events fire:

    listing.js:36 Uncaught ReferenceError: _gaq is not defined
    at HTMLAnchorElement.<anonymous>

The only thing that needs to be done is to set a class on the ad link so 
that we can identify it.

I've set up a click report here:

  https://analytics.google.com/analytics/web/#/analysis/p359226015/edit/bGLhChheTZCKyRszYcEd8A