### PR TITLE
Remove defunct webdrivers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,11 +59,11 @@ group :test do
   gem "elabs_matchers"
   gem "launchy"
   gem "rails-controller-testing" # TODO: refactor tests so that we don't need this
+  gem "selenium-webdriver", require: false
   gem "shoulda-matchers"
   gem "simplecov", require: false
   gem "timecop"
   gem "vcr"
-  gem "webdrivers", require: false
   gem "webmock"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,7 +179,7 @@ GEM
     memcachier (0.0.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.2)
+    mini_portile2 (2.8.4)
     minitest (5.18.0)
     msgpack (1.7.1)
     multi_xml (0.6.0)
@@ -193,7 +193,7 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
-    nokogiri (1.15.2)
+    nokogiri (1.15.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     oauth2 (2.0.9)
@@ -229,7 +229,7 @@ GEM
     public_suffix (5.0.1)
     puma (6.2.2)
       nio4r (~> 2.0)
-    racc (1.6.2)
+    racc (1.7.1)
     rack (2.2.7)
     rack-attack (6.6.1)
       rack (>= 1.0, < 3)
@@ -282,7 +282,7 @@ GEM
     regexp_parser (2.8.0)
     request_store (1.5.1)
       rack (>= 1.4)
-    rexml (3.2.5)
+    rexml (3.2.6)
     rollbar (3.4.0)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
@@ -341,7 +341,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    selenium-webdriver (4.9.1)
+    selenium-webdriver (4.10.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -387,10 +387,6 @@ GEM
     uniform_notifier (1.16.0)
     vcr (6.1.0)
     version_gem (1.1.2)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -452,6 +448,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   sassc-rails
+  selenium-webdriver
   shoulda-matchers
   simplecov
   sprockets
@@ -461,7 +458,6 @@ DEPENDENCIES
   timecop
   turbo-rails
   vcr
-  webdrivers
   webmock
 
 RUBY VERSION

--- a/spec/support/system/drivers.rb
+++ b/spec/support/system/drivers.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "webdrivers/chromedriver"
-
 module System
   module Drivers
     RSpec.configure do |config|


### PR DESCRIPTION
Got errors about chrome in specs:

    Webdrivers::VersionError:
              Unable to find latest point release version for 115.0.5790. You appear to be using a non-production version of Chrome.

...Then after upgrading the `webdrivers` gem, got this message:

    Webdrivers gem update options
    *****************************

    Selenium itself now manages drivers by default: https://www.selenium.dev/documentation/selenium_manager
    * If you are using Ruby 3+ — please update to Selenium 4.11+ and stop requiring this gem
    * If you are using Ruby 2.6+ and Selenium 4.0+ — this version will work for now
    * If you use Ruby < 2.6 or Selenium 3, a 6.0 version of this gem with additional support is planned

Upgrading selenium-webdriver and removing my locally Homebrew-installed
version of chromedriver resolved this issue.