### PR TITLE
Remove "Event type"

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -72,7 +72,6 @@ class EventsController < CmsBaseController
         venue_id
         social_organiser_id
         class_organiser_id
-        event_type
         has_taster
         has_class
         has_social

--- a/app/controllers/name_clash_controller.rb
+++ b/app/controllers/name_clash_controller.rb
@@ -4,7 +4,7 @@ class NameClashController < ApplicationController
   layout "name_clash"
 
   def index
-    names = Event.socials.non_gigs.pluck(:title)
+    names = Event.socials.where.not(event_type: "gig").pluck(:title)
 
     @names = names.map do |s|
       s.gsub(

--- a/app/forms/create_event_form.rb
+++ b/app/forms/create_event_form.rb
@@ -7,7 +7,6 @@ class CreateEventForm
   attribute :title, :string
   attribute :url, :string
   attribute :venue_id, :integer
-  attribute :event_type, :string
 
   attribute :has_social, :boolean
   attribute :social_organiser_id, :integer
@@ -31,7 +30,6 @@ class CreateEventForm
 
   validates :url, presence: true, uri: true
   validates :venue_id, presence: true
-  validates :event_type, presence: true
   validates :frequency, presence: true
   validates :course_length, numericality: { only_integer: true, greater_than: 0, allow_blank: true }
 

--- a/app/forms/edit_event_form.rb
+++ b/app/forms/edit_event_form.rb
@@ -12,7 +12,6 @@ class EditEventForm < CreateEventForm
           title: event.title,
           url: event.url,
           venue_id: event.venue_id,
-          event_type: event.event_type,
 
           has_social: event.has_social,
           social_organiser_id: event.social_organiser_id,

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -13,16 +13,6 @@ module EventsHelper
     Organiser.all.collect { |o| [o.name, o.id] }
   end
 
-  def event_type_select
-    [
-      ["School", "organised by a dance school", "school"],
-      ["Dance Club", "organised for dancers", "dance_club"],
-      ["Vintage Club", "not aimed at dancers", "vintage_club"],
-      ["Gig", "not aimed at dancers", "gig"],
-      ["Festival", "part of a larger event", "festival"]
-    ].freeze
-  end
-
   # ----- #
   # LINKS #
   # ----- #

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -16,7 +16,6 @@ class Event < ApplicationRecord
   has_many :events_swing_cancellations, dependent: :destroy
   has_many :swing_cancellations, -> { distinct(true) }, through: :events_swing_cancellations, source: :swing_date
 
-  validates :event_type, presence: true
   validates :frequency, presence: true
   validates :url, presence: true, uri: true
 
@@ -92,8 +91,6 @@ class Event < ApplicationRecord
   scope :weekly, -> { where(frequency: 1) }
   scope :weekly_or_fortnightly, -> { where(frequency: [1, 2]) }
   scope :less_frequent, -> { where(frequency: 0).or(where(frequency: 4..52)) }
-
-  scope :non_gigs, -> { where.not(event_type: "gig") }
 
   scope :active, -> { where("last_date IS NULL OR last_date > ?", Date.current) }
   scope :ended, -> { where("last_date IS NOT NULL AND last_date < ?", Date.current) }

--- a/app/presenters/show_event.rb
+++ b/app/presenters/show_event.rb
@@ -39,7 +39,7 @@ class ShowEvent
     activities << "social" if event.has_social?
     activities << "taster" if event.has_taster?
     activities << "class" if event.has_class?
-    "#{event.event_type.humanize}, with #{activities.join(' and ')}"
+    activities.join(" with ").capitalize
   end
 
   def frequency # rubocop:disable Metrics/MethodLength

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -11,17 +11,6 @@
       <%= f.label :venue_id, 'Venue' %>
       <%= f.select :venue_id, venue_select, { include_blank: true} %>
     </div>
-    <div class='form-group'>
-      <h4 class="form-group-title">Event Type</h4>
-
-      <% event_type_select.each do |description, help, value| %>
-        <label>
-          <%= f.radio_button(:event_type, value) %>
-          <%= description %>
-          <span class="help"><%= help %></span>
-        </label>
-      <% end %>
-    </div>
   </section>
 
   <% if @form.persisted? %>

--- a/spec/form_spec_helper.rb
+++ b/spec/form_spec_helper.rb
@@ -17,7 +17,6 @@ FactoryBot.define do
     has_taster { false }
     has_class { false }
     has_social { true }
-    event_type { "school" }
     frequency { 0 }
     url { Faker::Internet.url }
     venue_id { rand(999) }

--- a/spec/forms/create_event_form_spec.rb
+++ b/spec/forms/create_event_form_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe CreateEventForm do
     it_behaves_like "validates course length", :create_event_form
     it_behaves_like "validates url", :create_event_form
 
-    it { is_expected.to validate_presence_of(:event_type) }
     it { is_expected.to validate_presence_of(:frequency) }
     it { is_expected.to validate_presence_of(:url) }
     it { is_expected.to validate_presence_of(:venue_id) }

--- a/spec/forms/edit_event_form_spec.rb
+++ b/spec/forms/edit_event_form_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe EditEventForm do
     it_behaves_like "validates course length", :edit_event_form
     it_behaves_like "validates url", :edit_event_form
 
-    it { is_expected.to validate_presence_of(:event_type) }
     it { is_expected.to validate_presence_of(:frequency) }
     it { is_expected.to validate_presence_of(:url) }
     it { is_expected.to validate_presence_of(:venue_id) }

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -191,7 +191,6 @@ describe Event do
       expect(event.errors.messages).to eq(venue: ["must exist"])
     end
 
-    it { is_expected.to validate_presence_of(:event_type) }
     it { is_expected.to validate_presence_of(:frequency) }
     it { is_expected.to validate_presence_of(:url) }
 

--- a/spec/presenters/show_event_spec.rb
+++ b/spec/presenters/show_event_spec.rb
@@ -100,19 +100,29 @@ RSpec.describe ShowEvent do
   describe "#event_type" do
     context "when the event is a class" do
       it "combines event type and class" do
-        event = instance_double("Event", event_type: "school", has_social?: false, has_taster?: false, has_class?: true)
+        event = instance_double("Event", has_social?: false, has_taster?: false, has_class?: true)
 
-        expect(described_class.new(event).event_type).to eq "School, with class"
+        expect(described_class.new(event).event_type).to eq "Class"
       end
     end
 
-    context "when the event is a club with a taster" do
-      it "combines event type, social and taster" do
+    context "when the event is a social with a class" do
+      it "combines social and taster" do
         event = instance_double(
-          "Event", event_type: "dance_club", has_social?: true, has_taster?: true, has_class?: false
+          "Event", has_social?: true, has_taster?: false, has_class?: true
         )
 
-        expect(described_class.new(event).event_type).to eq "Dance club, with social and taster"
+        expect(described_class.new(event).event_type).to eq "Social with class"
+      end
+    end
+
+    context "when the event is a social with a taster" do
+      it "combines social and taster" do
+        event = instance_double(
+          "Event", has_social?: true, has_taster?: true, has_class?: false
+        )
+
+        expect(described_class.new(event).event_type).to eq "Social with taster"
       end
     end
   end

--- a/spec/system/admins_can_create_events_spec.rb
+++ b/spec/system/admins_can_create_events_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe "Admins can create events", :js do
       autocomplete_select "The 100 Club", from: "Venue"
       autocomplete_select "The London Swing Dance Society", from: "Social organiser"
       autocomplete_select "The London Swing Dance Society", from: "Class organiser"
-      choose "School" # Event Type
       check "Has a taster?"
       check "Has social?"
       choose "Other (balboa, shag etc)"
@@ -39,7 +38,7 @@ RSpec.describe "Admins can create events", :js do
         .and have_content("Venue:\nThe 100 Club")
         .and have_content("Social Organiser:\nThe London Swing Dance Society")
         .and have_content("Class Organiser:\nThe London Swing Dance Society")
-        .and have_content("School, with social and taster")
+        .and have_content("Social with taster")
         .and have_content("Class style:\nBalboa")
         .and have_content("Frequency:\nMonthly or occasionally")
         .and have_content("Dates:\n12/12/2012, 19/12/2012")
@@ -61,15 +60,13 @@ RSpec.describe "Admins can create events", :js do
 
       click_button "Create"
 
-      expect(page).to have_content("5 errors prevented this record from being saved")
+      expect(page).to have_content("4 errors prevented this record from being saved")
         .and have_content("Venue can't be blank")
         .and have_content("Url can't be blank")
-        .and have_content("Event type can't be blank")
         .and have_content("Frequency can't be blank")
         .and have_content("Events must have either a Social or a Class")
 
       autocomplete_select "The 100 Club", from: "Venue"
-      choose "School" # Event Type
       check "Has social?"
       fill_in "Title", with: "Stompin'"
       choose "Weekly"
@@ -79,7 +76,7 @@ RSpec.describe "Admins can create events", :js do
       click_button "Create"
 
       expect(page).to have_content("Venue:\nThe 100 Club")
-        .and have_content("School, with social")
+        .and have_content("Social")
         .and have_content("Frequency:\nWeekly on Tuesdays")
         .and have_content("Url:\nhttp://www.lsds.co.uk/stompin")
     end
@@ -113,7 +110,6 @@ RSpec.describe "Admins can create events", :js do
 
       autocomplete_select "Dogstar", from: "Venue"
       autocomplete_select "Sunshine Swing", from: "Class organiser"
-      choose "School" # Event Type
       check "Has a class?"
       choose "Weekly"
       select "Wednesday", from: "Day"
@@ -126,7 +122,7 @@ RSpec.describe "Admins can create events", :js do
 
       expect(page).to have_content("Venue:\nDogstar")
         .and have_content("Class Organiser:\nSunshine Swing")
-        .and have_content("School, with class")
+        .and have_content("Class")
         .and have_content("Frequency:\nWeekly on Wednesdays")
         .and have_content("Cancelled:\nNone")
         .and have_content("First date:\nWednesday 16th February")
@@ -147,15 +143,13 @@ RSpec.describe "Admins can create events", :js do
 
       click_button "Create"
 
-      expect(page).to have_content("5 errors prevented this record from being saved")
+      expect(page).to have_content("4 errors prevented this record from being saved")
         .and have_content("Venue can't be blank")
         .and have_content("Url can't be blank")
-        .and have_content("Event type can't be blank")
         .and have_content("Frequency can't be blank")
         .and have_content("Events must have either a Social or a Class")
 
       autocomplete_select "Dogstar", from: "Venue"
-      choose "School" # Event Type
       check "Has a class?"
       choose "Weekly"
       select "Tuesday", from: "Day"
@@ -171,7 +165,7 @@ RSpec.describe "Admins can create events", :js do
 
       expect(page).to have_content("Venue:\nDogstar")
         .and have_content("Class Organiser:\nSunshine Swing")
-        .and have_content("School, with class")
+        .and have_content("Class")
         .and have_content("Frequency:\nWeekly on Tuesdays")
         .and have_content("Url:\nhttps://sunshineswing.uk/events")
     end

--- a/spec/system/admins_can_edit_events_spec.rb
+++ b/spec/system/admins_can_edit_events_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe "Admins can edit events", :js do
     autocomplete_select "The 100 Club", from: "Venue"
     autocomplete_select "The London Swing Dance Society", from: "Social organiser"
     autocomplete_select "The London Swing Dance Society", from: "Class organiser"
-    choose "School" # Event Type
     check "Has a taster?"
     check "Has social?"
     choose "Lindy Hop or general swing"
@@ -37,7 +36,7 @@ RSpec.describe "Admins can edit events", :js do
       .and have_content("Venue:\nThe 100 Club")
       .and have_content("Social Organiser:\nThe London Swing Dance Society")
       .and have_content("Class Organiser:\nThe London Swing Dance Society")
-      .and have_content("School, with social and taster")
+      .and have_content("Social with taster")
       .and have_content("Class style:\nLindy Hop or general swing")
       .and have_content("Frequency:\nMonthly or occasionally")
       .and have_content("First date:")

--- a/spec/system/smoke_spec.rb
+++ b/spec/system/smoke_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe "Adding a new event" do
     select "The Savoy Ballroom", from: "Venue"
     select "Herbert White", from: "Social organiser"
     select "Frankie Manning", from: "Class organiser"
-    choose "Dance Club" # Event Type
     uncheck "Has a taster?"
     check "Has a class?"
     check "Has social?"


### PR DESCRIPTION
This hasn't actually been used by anything since we removed the Gig
label and the separate section of the events list.

This is preliminary to changing the approach for the event form to
show/hide different fields.