### PR TITLE
Fix: Display nicely when forms break

### DIFF
--- a/app/assets/stylesheets/cms/forms.scss
+++ b/app/assets/stylesheets/cms/forms.scss
@@ -207,3 +207,16 @@ a.normal-link {
 #error-explanation li {
   font-size: 14px;
 }
+
+.field_with_errors {
+  input,
+  select {
+    border: 2px solid #c00;
+  }
+}
+
+// For radio buttons, the input is inside the label
+label .field_with_errors {
+  display: inline-block;
+  border: 2px solid #c00;
+}


### PR DESCRIPTION
Previously this broke the layout for radio buttons since they're
displayed inline, but get wrapped in a div (with a class of
field_with_errors) so got displayed on the next line.

Show a red border while we're at it.

BEFORE:
<img width="497" alt="Screenshot 2023-10-01 at 23 08 00" src="https://github.com/dgmstuart/swing-out-london/assets/393167/258baaf6-e78a-4d17-8e3e-7ef05cd3b48a">

AFTER:
<img width="1007" alt="Screenshot 2023-10-01 at 23 03 52" src="https://github.com/dgmstuart/swing-out-london/assets/393167/0486f03b-23fc-4aa1-baf4-9fdd2efc2f3e">
<img width="646" alt="Screenshot 2023-10-01 at 23 04 02" src="https://github.com/dgmstuart/swing-out-london/assets/393167/195893f1-9e40-4403-8f1d-d5a2eab6e5e4">
<img width="668" alt="Screenshot 2023-10-01 at 23 05 03" src="https://github.com/dgmstuart/swing-out-london/assets/393167/56b72519-b7aa-405e-9d27-f1d70456671a">

