### PR TITLE
Remove unused analytics events js

### DIFF
--- a/app/javascript/application/listing.js
+++ b/app/javascript/application/listing.js
@@ -4,11 +4,6 @@ export function initListings() {
   if (document.body.classList.contains('listings') && document.body.classList.contains('index')) {
     var timeago = document.querySelector('time.timeago')
     timeago.innerHTML = format(timeago.getAttribute('time'));
-    add_socials_analytics_events();
-    add_advertisement_analytics_events();
-    add_donation_button_analytics_event();
-    add_facebook_share_analytics_event();
-    add_tweet_share_analytics_event();
     add_facebook_share_click_handler();
   }
 };


### PR DESCRIPTION
These should have been removed in ad54f69, which moved to Google
Analytics 4 link tracking and removed these methods.