### PR TITLE
Run db:schema:load on initial deploy

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-release: bundle exec rake db:migrate
+release: bundle exec rake release
 web: bundle exec puma -C config/puma.rb

--- a/bin/setup
+++ b/bin/setup
@@ -26,7 +26,7 @@ class Setup
       end
 
       puts "\n== Preparing database =="
-      system! 'bin/rails db:setup'
+      system! 'bin/rails release'
 
       puts "\n== Removing old logs and tempfiles =="
       system! 'bin/rails log:clear tmp:clear'

--- a/lib/tasks/release.rake
+++ b/lib/tasks/release.rake
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+task ensure_schema: %w[environment] do
+  # `current_version` fails the same way `db:version` does if there's something seriously wrong
+  is_new_database = ActiveRecord::Base.connection.migration_context.current_version.zero?
+  Rake::Task["db:schema:load"].invoke if is_new_database
+end
+
+task release: %w[environment ensure_schema db:migrate]


### PR DESCRIPTION
The issue here is that Heroku always tries to run rake db:migrate even
on a completely fresh install. But I'm not trying to maintain the
migrations so that they can be run completely from scratch - instead the
approach is to run rake db:schema:load to create the database, and then
to run `rake db:migrate` for subsequent releases.

This rake task (modified from
https://gist.github.com/stevenharman/98576bf49b050b9e59fb26626b7cceff?permalink_comment_id=4332071#gistcomment-4332071)
achieves this.