### PR TITLE
Enable controller caching in test

### DIFF
--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -15,6 +15,8 @@ class ListingsController < ApplicationController
   end
 
   def action_cache_key
+    return if Audit.none?
+
     "listings-#{Audit.last.cache_key}"
   end
 end

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -51,7 +51,7 @@ class MapsController < ApplicationController
 
   def action_cache_key
     values = params.values_at(:controller, :action, :day, :date, :venue_id).compact
-    values << Audit.last.cache_key
+    values << Audit.last.cache_key if Audit.any?
     values.join("-")
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
+  config.action_controller.perform_caching = true
   config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.


### PR DESCRIPTION
This is to ensure that we exercise the cache keys in tests. Maybe this
is a bad idea. I'm not sure exactly what what config option enables.