### PR TITLE
Cover InfoPage with specs

### DIFF
--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Config
+  def initialize(app_root: Rails.root, yaml_loader: YAML)
+    @app_root = app_root
+    @yaml_loader = yaml_loader
+  end
+
+  def load(file_name)
+    file_path = app_root.join("config", file_name).to_s
+    yaml_loader.load_file(file_path).deep_symbolize_keys
+  end
+
+  private
+
+  attr_reader :app_root, :yaml_loader
+end

--- a/app/models/info_page.rb
+++ b/app/models/info_page.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class InfoPage
-  def initialize(page)
-    pages_config = load_config_file("info_pages.yml")
-    @page = pages_config.fetch(page)
+  def initialize(page_name, pages: InfoPages.new, city: CITY.key)
+    @page = pages.page(page_name)
+    @city = city
   end
 
   def content_partials
@@ -17,16 +17,21 @@ class InfoPage
   private
 
   def partials(key)
-    @page.fetch(CITY.key).fetch(key).map { Partial.new(root, _1) }
+    @page.fetch(@city).fetch(key).map { Partial.new(root, _1) }
   end
 
   def root
     @page.fetch(:dir_path)
   end
 
-  def load_config_file(filename)
-    file_path = Rails.root.join("config", filename)
-    YAML.load_file(file_path).deep_symbolize_keys
+  class InfoPages
+    def initialize(config: Config.new.load("info_pages.yml"))
+      @config = config
+    end
+
+    def page(page_name)
+      @config.fetch(page_name)
+    end
   end
 
   class Partial

--- a/spec/models/config_spec.rb
+++ b/spec/models/config_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "app/models/config"
+require "active_support/core_ext/hash"
+
+RSpec.describe Config do
+  describe "#load" do
+    it "loads config from a YAML file" do
+      content = { "foo" => { "bar" => "baz" } }
+      app_root = Pathname.new("/Users/me/dev/swing-out-london")
+      yaml_loader = class_double(YAML, load_file: content)
+
+      config = described_class.new(app_root:, yaml_loader:)
+      config.load("qux.yml")
+
+      expect(yaml_loader).to have_received(:load_file)
+        .with("/Users/me/dev/swing-out-london/config/qux.yml")
+    end
+
+    it "returns the file content as a symbol hash" do
+      content = { "foo" => { "bar" => "baz" } }
+      app_root = Pathname.new("/")
+      yaml_loader = class_double(YAML, load_file: content)
+
+      config = described_class.new(app_root:, yaml_loader:)
+      result = config.load("qux.yml")
+
+      expect(result.fetch(:foo).fetch(:bar)).to eq "baz"
+    end
+  end
+end

--- a/spec/models/info_page_spec.rb
+++ b/spec/models/info_page_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "app/models/info_page"
+
+describe InfoPage do
+  describe "#content_partials" do
+    it "returns the list of content partials for the current city" do # rubocop:disable RSpec/ExampleLength
+      config = {
+        dir_path: "foo/about",
+        london: {
+          content: %w[about_london london_history]
+        },
+        bristol: {
+          content: %w[about_bristol bristol_history]
+        }
+      }
+      pages = instance_double("InfoPages", page: config)
+
+      page = described_class.new(:about, pages:, city: :london)
+
+      aggregate_failures do
+        partials = page.content_partials
+        expect(partials[0].path).to eq "foo/about/about_london"
+        expect(partials[0].name).to eq "about_london"
+        expect(partials[1].path).to eq "foo/about/london_history"
+        expect(partials[1].name).to eq "london_history"
+      end
+    end
+  end
+
+  describe "#sidebar_partials" do
+    it "returns the list of content partials for the current city" do # rubocop:disable RSpec/ExampleLength
+      config = {
+        dir_path: "foo/about",
+        london: {
+          sidebar: %w[lindy_hop about_us_london]
+        },
+        bristol: {
+          sidebar: %w[lindy_hop about_us_bristol]
+        }
+      }
+      pages = instance_double("InfoPages", page: config)
+
+      page = described_class.new(:about, pages:, city: :bristol)
+
+      aggregate_failures do
+        partials = page.sidebar_partials
+        expect(partials[0].path).to eq "foo/about/lindy_hop"
+        expect(partials[0].name).to eq "lindy_hop"
+        expect(partials[1].path).to eq "foo/about/about_us_bristol"
+        expect(partials[1].name).to eq "about_us_bristol"
+      end
+    end
+  end
+end

--- a/spec/system/users_can_see_info_pages_spec.rb
+++ b/spec/system/users_can_see_info_pages_spec.rb
@@ -21,4 +21,27 @@ RSpec.describe "Users can see Info pages" do
     expect(page).to have_content("Location")
       .and have_content("swingoutlondon@gmail.com")
   end
+
+  context "when the city is Bristol" do
+    before { stub_const("CITY", City.build_bristol) }
+
+    it "Users can see an about page" do
+      visit "/"
+      within "#main_nav" do
+        click_link "About"
+      end
+
+      expect(page).to have_content("About Swing Out Bristol")
+    end
+
+    it "Users can see a listings policy" do
+      visit "/"
+      within "#main_nav" do
+        click_link "Listings Policy"
+      end
+
+      expect(page).to have_content("Location")
+        .and have_content("swingoutbristol@gmail.com")
+    end
+  end
 end


### PR DESCRIPTION
"config" as a name is maybe a bit too general, since this only deals
with YAML files, but I don't want to have the file type in the name
either.