### PR TITLE
Fix: properly apply "weekly can't have dates"

### DIFF
--- a/app/forms/create_event_form.rb
+++ b/app/forms/create_event_form.rb
@@ -37,6 +37,7 @@ class CreateEventForm
 
   validates_with ValidSocialOrClass
   validates_with ValidWeeklyEvent
+  validates_with Form::ValidEventWithDates
 
   def action
     "Create"

--- a/app/forms/edit_event_form.rb
+++ b/app/forms/edit_event_form.rb
@@ -63,6 +63,7 @@ class EditEventForm
 
   validates_with ValidSocialOrClass
   validates_with ValidWeeklyEvent
+  validates_with Form::ValidEventWithDates
 
   def action
     "Update"

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -25,6 +25,7 @@ class Event < ApplicationRecord
 
   validate :has_class_or_social
   validate :must_be_weekly_if_no_social
+  validate :cannot_be_weekly_and_have_dates
 
   validates_with ValidSocialOrClass
   validates_with ValidWeeklyEvent
@@ -85,6 +86,12 @@ class Event < ApplicationRecord
     return if has_social? || weekly? || frequency.nil?
 
     errors.add(:frequency, "must be 1 (weekly) for events without a social")
+  end
+
+  def cannot_be_weekly_and_have_dates
+    return unless weekly? && swing_dates.any?
+
+    errors.add(:swing_dates, "must be empty for weekly events")
   end
 
   # ----- #

--- a/app/validators/form/valid_event_with_dates.rb
+++ b/app/validators/form/valid_event_with_dates.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Form
+  class ValidEventWithDates < ActiveModel::Validator
+    def validate(event)
+      cannot_be_weekly_and_have_dates(event)
+    end
+
+    private
+
+    def cannot_be_weekly_and_have_dates(event)
+      return unless event.weekly? && event.dates.present? # ANY text in the dates field is considered invalid
+
+      event.errors.add(:dates, "must be empty for weekly events")
+    end
+  end
+end

--- a/app/validators/valid_weekly_event.rb
+++ b/app/validators/valid_weekly_event.rb
@@ -3,7 +3,6 @@
 class ValidWeeklyEvent < ActiveModel::Validator
   def validate(event)
     weekly_events_must_have_day(event)
-    cannot_be_weekly_and_have_dates(event)
   end
 
   private
@@ -12,11 +11,5 @@ class ValidWeeklyEvent < ActiveModel::Validator
     return unless event.weekly? && event.day.blank?
 
     event.errors.add(:day, "must be present for weekly events")
-  end
-
-  def cannot_be_weekly_and_have_dates(event)
-    return unless event.weekly? && event.dates.present?
-
-    event.errors.add(:dates, "must be empty for weekly events")
   end
 end

--- a/spec/forms/create_event_form_spec.rb
+++ b/spec/forms/create_event_form_spec.rb
@@ -5,9 +5,11 @@ require "config/initializers/inflections" # because of URI in URIValidator
 require "app/validators/uri_validator"
 require "app/validators/valid_social_or_class"
 require "app/validators/valid_weekly_event"
+require "app/validators/form/valid_event_with_dates"
 require "app/forms/create_event_form"
 require "spec/support/shared_examples/events/form/validates_class_and_social"
 require "spec/support/shared_examples/events/validates_weekly"
+require "spec/support/shared_examples/events/form/validates_event_with_dates"
 require "spec/support/shared_examples/events/validates_course_length"
 require "spec/support/shared_examples/validates_url"
 
@@ -19,6 +21,7 @@ RSpec.describe CreateEventForm do
 
     it_behaves_like "validates class and social (form)", :create_event_form
     it_behaves_like "validates weekly", :create_event_form
+    it_behaves_like "validates event with dates (form)", :create_event_form
     it_behaves_like "validates course length", :create_event_form
     it_behaves_like "validates url", :create_event_form
 

--- a/spec/forms/edit_event_form_spec.rb
+++ b/spec/forms/edit_event_form_spec.rb
@@ -5,10 +5,12 @@ require "config/initializers/inflections" # because of URI in URIValidator
 require "app/validators/uri_validator"
 require "app/validators/valid_social_or_class"
 require "app/validators/valid_weekly_event"
+require "app/validators/form/valid_event_with_dates"
 require "app/forms/create_event_form"
 require "app/forms/edit_event_form"
 require "spec/support/shared_examples/events/form/validates_class_and_social"
 require "spec/support/shared_examples/events/validates_weekly"
+require "spec/support/shared_examples/events/form/validates_event_with_dates"
 require "spec/support/shared_examples/events/validates_course_length"
 require "spec/support/shared_examples/validates_url"
 
@@ -20,6 +22,7 @@ RSpec.describe EditEventForm do
 
     it_behaves_like "validates class and social (form)", :edit_event_form
     it_behaves_like "validates weekly", :edit_event_form
+    it_behaves_like "validates event with dates (form)", :edit_event_form
     it_behaves_like "validates course length", :edit_event_form
     it_behaves_like "validates url", :edit_event_form
 

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 require "support/shoulda_matchers"
 require "spec/support/shared_examples/events/validates_class_and_social"
 require "spec/support/shared_examples/events/validates_weekly"
+require "spec/support/shared_examples/events/validates_event_with_dates"
 require "spec/support/shared_examples/events/validates_course_length"
 require "spec/support/shared_examples/validates_url"
 
@@ -182,6 +183,7 @@ RSpec.describe Event do
 
     it_behaves_like "validates class and social", :event
     it_behaves_like "validates weekly", :event
+    it_behaves_like "validates event with dates", :event
     it_behaves_like "validates course length", :event
     it_behaves_like "validates url", :event
 

--- a/spec/support/shared_examples/events/form/validates_event_with_dates.rb
+++ b/spec/support/shared_examples/events/form/validates_event_with_dates.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "validates event with dates (form)" do |model_name|
+  it "is invalid if it's weekly and has dates" do
+    model = build(model_name, frequency: 1, day: 5, dates: ["12/10/2010"])
+    model.valid?
+    expect(model.errors.messages).to eq(dates: ["must be empty for weekly events"])
+  end
+
+  it "is valid if it's occasional and has dates" do
+    expect(build(model_name, frequency: 0, dates: ["12/10/2010"])).to be_valid
+  end
+end

--- a/spec/support/shared_examples/events/validates_event_with_dates.rb
+++ b/spec/support/shared_examples/events/validates_event_with_dates.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "validates event with dates" do |model_name|
+  it "is invalid if it's weekly and has dates" do
+    swing_dates = [build(:swing_date, date: "12/10/2010"), build(:swing_date, date: "12/11/2010")]
+    model = build(model_name, :weekly, swing_dates:)
+    model.valid?
+    expect(model.errors.messages).to eq(swing_dates: ["must be empty for weekly events"])
+  end
+
+  it "is valid if it's occasional and has dates" do
+    swing_dates = [build(:swing_date, date: "12/10/2010"), build(:swing_date, date: "12/11/2010")]
+    expect(build(model_name, frequency: 0, swing_dates:)).to be_valid
+  end
+end


### PR DESCRIPTION
We don't want weekly events to have dates - they probably won't be used,
but it adds confusion and we can't be as confident as we'd like to be.

The issue here was that a) we weren't testing this validation and b)
it needs to be different for the model and the form objects:

For the form objects, dates are a string. At the moment we're not
actually doing any validation on that string, but we want to require the
field to be empty if it's weekly

For the model, a `dates` method exists, but it's the tip of a very messy
iceberg related to the insane way that dates are managed.

Instead the thing that we care about is whether there are any SwingDate
records associated with the Event.

Actually I'm not 100% sure about this, since SwingDate is a separate
model, so Events can become invalid by adding records in a separate
model, which feels wrong.

But this is a safety net: everything _should_ get caught by the form
object validations.