### PR TITLE
Fix development login

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,5 +1,14 @@
 # frozen_string_literal: true
 
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider(
+    :facebook,
+    ENV.fetch("FACEBOOK_APP_ID", nil),
+    ENV.fetch("FACEBOOK_SECRET", nil),
+    scope: "" # Don't request _any_ data - just the basic profile
+  )
+end
+
 if Rails.env.development? && ENV.fetch("SKIP_LOGIN", "false") == "true"
   require "omniauth_test_response_builder"
   require "faker/facebook"
@@ -10,13 +19,4 @@ if Rails.env.development? && ENV.fetch("SKIP_LOGIN", "false") == "true"
   I18n.load_path += Dir[Rails.root.join("config/locales/*.{rb,yml}").to_s]
 
   OmniauthTestResponseBuilder.new.stub_auth_hash(id: login_user_id)
-else
-  Rails.application.config.middleware.use OmniAuth::Builder do
-    provider(
-      :facebook,
-      ENV.fetch("FACEBOOK_APP_ID", nil),
-      ENV.fetch("FACEBOOK_SECRET", nil),
-      scope: "" # Don't request _any_ data - just the basic profile
-    )
-  end
 end


### PR DESCRIPTION
Previously I made it so that we _either_ configure the OmniAuth
provider _or_ set it up in test mode.

But without configuring the provider, there's no auth link to POST to!

I guess it doesn't actually need real values in order to work: nil is
fine.