### PR TITLE
Bad organiser links show 404 instead of root

### DIFF
--- a/app/controllers/external_events_controller.rb
+++ b/app/controllers/external_events_controller.rb
@@ -27,11 +27,9 @@ class ExternalEventsController < CmsBaseController
 
   def authenticate
     organiser_token = params[:id]
-    if Event.where(organiser_token:).load.exists?
-      @current_user = OrganiserUser.new(organiser_token)
-    else
-      redirect_to root_path
-    end
+    Event.find_by!(organiser_token:)
+
+    @current_user = OrganiserUser.new(organiser_token)
   end
 
   def event_params

--- a/spec/system/organisers_can_edit_events_spec.rb
+++ b/spec/system/organisers_can_edit_events_spec.rb
@@ -144,10 +144,8 @@ RSpec.describe "Organisers can edit events" do
   end
 
   context "when the organiser token is incorrect" do
-    it "redirects to the homepage" do
-      visit("/external_events/abc123/edit")
-
-      expect(page).to have_content("Listings")
+    it "renders a 404" do
+      expect { visit("/external_events/abc123/edit") }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 end


### PR DESCRIPTION
When an organiser link doesn’t work (eg. because it’s been refreshed, or
there’s a typo) currently we bounce them to the homepage, which is a
confusing experience.

Instead we should show them the Not Found page.