### PR TITLE
Use Jost through Google Fonts as a Futura fallback

### DIFF
--- a/app/assets/stylesheets/shared/base.scss
+++ b/app/assets/stylesheets/shared/base.scss
@@ -5,7 +5,7 @@ $body_font_size: 14px;
 body {
   // Disable automatic font zooming:
   text-size-adjust: 100%;
-  font-family: Futura, "Tw Cen MT", "Trebuchet MS", sans-serif;
+  font-family: Futura, Jost, "Tw Cen MT", "Trebuchet MS", sans-serif;
   color: $text-colour;
   font-size: $body_font_size;
 

--- a/app/views/info/about/_colophon.md
+++ b/app/views/info/about/_colophon.md
@@ -1,8 +1,10 @@
 ## Colophon
 
 * The styling of the site was inspired by vintage playbills, magazine listings and event posters.
-  The primary font used is [Futura](http://en.wikipedia.org/wiki/Futura_\(typeface\) "Wikipedia - Futura")
-  (falling back to Trebuchet MS on Windows) which was designed in 1927.
+  The primary font used is [Futura](http://en.wikipedia.org/wiki/Futura_\(typeface\) "Wikipedia - Futura") which was designed in 1927.
+
+* When Futura is not installed (eg. on Windows computers) [Jost](https://fonts.google.com/specimen/Jost) is used -
+  a free font heavily inspired by Futura which is distributed through [Google Fonts](https://fonts.google.com/)
 
 * The [vintage wallpaper](http://zebiii.deviantart.com/art/Patterns-2-94330934 "Patterns.2 by ZeBii on DeviantArt")
   in the background is by [ZeBii on DeviantArt](http://zebiii.deviantart.com/)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,7 @@
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <%= csrf_meta_tag %>
     <%= javascript_include_tag :application, defer: true %>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Jost:wght@500&display=swap">
     <%= stylesheet_link_tag 'application', media: "screen" %>
     <meta content="none" name="msapplication-config"/>
     <%= yield :head %>


### PR DESCRIPTION
Jost is pretty close to Futura, but I'm not quite confident enough to
switch to using it as the primary font.

Also not feeling like paying for a Futura license.