### PR TITLE
Fix title on map classes page

### DIFF
--- a/app/views/maps/classes.html.erb
+++ b/app/views/maps/classes.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-  <%= tc("site_name") %>'s Lindy Map:
+  <%= tc("site_name") %>'s Lindy Map: Classes
   <% if @day %>
     on #{ @day.pluralize }
   <% end %>


### PR DESCRIPTION
Otherwise it just says "Swing Out London's Lindy Map:" on the SERP