### PR TITLE
Redirect old OpenGraph image requests

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,4 +49,5 @@ Rails.application.routes.draw do
   get "apple-touch-icon-precomposed" => "application#not_found"
   get "apple-touch-icon-:size-precomposed" => "application#not_found"
   get "apple-app-site-association" => "application#not_found"
+  get "swingoutlondon_og.png" => redirect(ActionController::Base.helpers.image_path(CITY.opengraph_image))
 end


### PR DESCRIPTION
New Facebook shares correctly get the new image, but for some reason we
have a bunch of hits from Facebook requesting the old url, which was
just /swingoutlondon_og.png. This is the User Agent:

    facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)

Scraping the page from this URL was what made sharing work correctly,
but maybe Facebook has other caches for other uses somewhere:

  https://developers.facebook.com/tools/debug/?q=https%3A%2F%2Fwww.swingoutlondon.co.uk

Not sure what would be impacted - old share links?

Whatever: let's just redirect them to the new image URL.