### PR TITLE
Map socials expired dates redirect with 301

### DIFF
--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -46,7 +46,7 @@ class MapsController < ApplicationController
       )
   rescue Maps::Socials::Dates::DateOutOfRangeError
     logger.warn("Not a date in the visible range: #{@date}")
-    redirect_to map_socials_path
+    redirect_to map_socials_path, status: :moved_permanently
   end
 
   def action_cache_key


### PR DESCRIPTION
This is for the sake of webcrawlers. It seems like with 302, they'll
keep checking back to see if it's changed, but 301 is a stronger signal
that they don't need to keep checking (or at least to do so less
frequently).