### PR TITLE
Use Timecop in SOLDNTime spec

### DIFF
--- a/spec/lib/dates_string_parser_spec.rb
+++ b/spec/lib/dates_string_parser_spec.rb
@@ -2,6 +2,7 @@
 
 require "spec_helper"
 require "lib/dates_string_parser"
+require "active_support"
 require "active_support/core_ext/string/conversions"
 
 RSpec.describe DatesStringParser do

--- a/spec/models/login_session_spec.rb
+++ b/spec/models/login_session_spec.rb
@@ -2,6 +2,7 @@
 
 require "spec_helper"
 require "app/models/login_session"
+require "active_support"
 require "active_support/core_ext/object/blank"
 
 RSpec.describe LoginSession do

--- a/spec/models/return_to_session_spec.rb
+++ b/spec/models/return_to_session_spec.rb
@@ -2,7 +2,6 @@
 
 require "spec_helper"
 require "app/models/return_to_session"
-# require "active_support/core_ext/object/blank"
 
 RSpec.describe ReturnToSession do
   describe "store!" do

--- a/spec/models/soldn_time_spec.rb
+++ b/spec/models/soldn_time_spec.rb
@@ -2,10 +2,10 @@
 
 require "spec_helper"
 require "app/models/soldn_time"
+require "spec/support/time_formats_helper"
 require "active_support/testing/time_helpers"
 require "active_support/core_ext/string/zones"
 require "active_support/core_ext/numeric/time"
-require "spec/support/time_formats_helper"
 
 RSpec.describe SOLDNTime, :time do
   include ActiveSupport::Testing::TimeHelpers

--- a/spec/models/soldn_time_spec.rb
+++ b/spec/models/soldn_time_spec.rb
@@ -2,23 +2,23 @@
 
 require "spec_helper"
 require "app/models/soldn_time"
+require "timecop"
 require "spec/support/time_formats_helper"
-require "active_support/testing/time_helpers"
 require "active_support/core_ext/string/zones"
 require "active_support/core_ext/numeric/time"
+require "active_support/core_ext/object/blank"
 
 RSpec.describe SOLDNTime, :time do
-  include ActiveSupport::Testing::TimeHelpers
-
   describe "today" do
     context "when the timezone is UTC" do
       around do |example|
         Time.use_zone("UTC") { example.run }
+        Timecop.return
       end
 
       context "when the time is before midnight" do
         it "is the current date" do
-          travel_to(Time.zone.parse("May 11, 1938 19:00"))
+          Timecop.travel(Time.zone.parse("May 11, 1938 19:00"))
 
           expect(described_class.today.to_fs).to eq "11/05/1938"
         end
@@ -26,7 +26,7 @@ RSpec.describe SOLDNTime, :time do
 
       context "when the time is before 4am" do
         it "is the date that this crazy night began (yesterday's date)" do
-          travel_to(Time.zone.parse("May 12, 1938 03:59"))
+          Timecop.travel(Time.zone.parse("May 12, 1938 03:59"))
 
           expect(described_class.today.to_fs).to eq "11/05/1938"
         end
@@ -34,7 +34,7 @@ RSpec.describe SOLDNTime, :time do
 
       context "when the time is 4am" do
         it "is time to go to bed (today's date)" do
-          travel_to(Time.zone.parse("May 12, 1938 04:00"))
+          Timecop.travel(Time.zone.parse("May 12, 1938 04:00"))
 
           expect(described_class.today.to_fs).to eq "12/05/1938"
         end
@@ -44,11 +44,12 @@ RSpec.describe SOLDNTime, :time do
     context "when the timezone is BST" do
       around do |example|
         Time.use_zone("London") { example.run }
+        Timecop.return
       end
 
       context "when the time is before 4am" do
         it "is the date that this crazy night began (yesterday's date)" do
-          travel_to(Time.zone.parse("May 12, 1938 03:59"))
+          Timecop.travel(Time.zone.parse("May 12, 1938 03:59"))
 
           expect(described_class.today.to_fs).to eq "11/05/1938"
         end
@@ -56,7 +57,7 @@ RSpec.describe SOLDNTime, :time do
 
       context "when the time is 4am" do
         it "is time to go to bed (today's date)" do
-          travel_to(Time.zone.parse("May 12, 1938 04:00"))
+          Timecop.travel(Time.zone.parse("May 12, 1938 04:00"))
 
           expect(described_class.today.to_fs).to eq "12/05/1938"
         end
@@ -64,7 +65,7 @@ RSpec.describe SOLDNTime, :time do
 
       context "when the time is 5am" do
         it "is time to go to bed (today's date)" do
-          travel_to(Time.zone.parse("May 12, 1938 05:00"))
+          Timecop.travel(Time.zone.parse("May 12, 1938 05:00"))
 
           expect(described_class.today.to_fs).to eq "12/05/1938"
         end
@@ -114,10 +115,11 @@ RSpec.describe SOLDNTime, :time do
     context "when the start date is not specified" do
       around do |example|
         Time.use_zone("UTC") { example.run }
+        Timecop.return
       end
 
       it "defaults to today" do
-        travel_to(Time.zone.parse("Jan 1, 1928 19:00"))
+        Timecop.travel(Time.zone.parse("Jan 1, 1928 19:00"))
 
         result = described_class.listing_dates(number_of_days: 1)
 

--- a/spec/presenters/map/social_listing_spec.rb
+++ b/spec/presenters/map/social_listing_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "active_support"
 require "active_support/core_ext/module/delegation"
 require "app/presenters/social_listing"
 require "app/presenters/map/social_listing"

--- a/spec/presenters/postcode_spec.rb
+++ b/spec/presenters/postcode_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "active_support"
 require "active_support/core_ext/object/blank"
 require "app/presenters/postcode"
 

--- a/spec/presenters/show_event_spec.rb
+++ b/spec/presenters/show_event_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "active_support/core_ext/module/delegation"
 require "spec/support/time_formats_helper"
+require "active_support/core_ext/module/delegation"
 require "app/presenters/show_event"
 require "app/presenters/date_printer"
 

--- a/spec/presenters/social_listing_spec.rb
+++ b/spec/presenters/social_listing_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "active_support"
 require "active_support/core_ext/module/delegation"
 require "active_support/core_ext/string/conversions"
 require "app/presenters/social_listing"

--- a/spec/services/event_params_commenter_spec.rb
+++ b/spec/services/event_params_commenter_spec.rb
@@ -4,8 +4,8 @@ require "spec_helper"
 require "app/presenters/date_printable_event"
 require "app/presenters/date_printer"
 require "app/services/event_params_commenter"
-require "active_support/core_ext/string/conversions"
 require "spec/support/time_formats_helper"
+require "active_support/core_ext/string/conversions"
 
 RSpec.describe EventParamsCommenter do
   describe "#comment" do

--- a/spec/services/event_summarizer_spec.rb
+++ b/spec/services/event_summarizer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "active_support"
 require "active_support/core_ext/string/inflections"
 require "app/services/event_summarizer"
 

--- a/spec/services/socials_listings_spec.rb
+++ b/spec/services/socials_listings_spec.rb
@@ -2,6 +2,7 @@
 
 require "spec_helper"
 require "app/services/socials_listings"
+require "active_support"
 require "active_support/core_ext/string/conversions"
 
 RSpec.describe SocialsListings do

--- a/spec/support/time_formats_helper.rb
+++ b/spec/support/time_formats_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # All the parts of Rails required to load and use time formats in isolated specs
+require "active_support"
 require "active_support/core_ext/date/conversions"
 require "active_support/core_ext/time/conversions"
 require "active_support/core_ext/integer/inflections"

--- a/spec/system/smoke_spec.rb
+++ b/spec/system/smoke_spec.rb
@@ -3,9 +3,11 @@
 require "rails_helper"
 
 RSpec.describe "Adding a new event", :js do
-  it "with a social and a dance class" do
-    Timecop.freeze("01/01/1937T12:00")
+  around do |example|
+    Timecop.freeze("01/01/1937T12:00") { example.run }
+  end
 
+  it "with a social and a dance class" do
     stub_login
     visit "/events"
 


### PR DESCRIPTION
Rails 7.1 somehow doesn't play nicely here. Got a lot of "Stack level
too deep" errors. I guess because time helpers are doing something more
basic than Timecop - just stubbing the time classes. The individual
specs succeeded, but running the whole file several of them fail.

Also for some reason we only now need to require "active_support" before
using modules (supposedly it's always been required: https://guides.rubyonrails.org/active_support_core_extensions.html#stand-alone-active-support)

Also the definition of to_date now relies on blank? I guess?