### PR TITLE
Fix failing spec when clicking "Show"

### DIFF
--- a/spec/system/editors_can_archive_events_spec.rb
+++ b/spec/system/editors_can_archive_events_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Editors can archive events" do
       click_link "Archive", match: :first
     end
 
-    click_link "Show", match: :first
+    click_show
 
     expect(page).to have_content("Last date: Sunday 2nd January")
   end
@@ -29,7 +29,7 @@ RSpec.describe "Editors can archive events" do
       click_link "Archive", match: :first
     end
 
-    click_link "Show", match: :first
+    click_show
 
     expect(page).to have_content("Last date: Sunday 2nd January")
   end
@@ -42,8 +42,14 @@ RSpec.describe "Editors can archive events" do
 
     click_link "Archive", match: :first
 
-    click_link "Show", match: :first
+    click_show
 
     expect(page).to have_content("Last date: Monday 1st January") # earliest possible Date
+  end
+
+  def click_show
+    within ".actions.last", match: :first do
+      click_link "Show"
+    end
   end
 end


### PR DESCRIPTION
The issue here is that sometimes the event names generated by faker
include the word "Show".

In this case, with the seed 37153, the event generated for the middle
spec for "Archive" was "Dr Low's Medicine Show", and since that was the
first link in the page containing the text "Show", that's the link which
got clicked, and then failed since the URLs aren't real URLs.