### PR TITLE
Validation error for duplicate dates

### DIFF
--- a/app/validators/dates_string_validator.rb
+++ b/app/validators/dates_string_validator.rb
@@ -10,7 +10,8 @@ class DatesStringValidator < ActiveModel::EachValidator
         invalid: "contained some invalid dates",
         past: "contained some dates in the past",
         distant_past: "contained some dates in the distant past",
-        distant_future: "contained some dates unreasonably far in the future"
+        distant_future: "contained some dates unreasonably far in the future",
+        duplicate: "contained some dates more than once"
       }.fetch(type)
       message = "#{description}: #{problem_dates.join(', ')}"
 

--- a/spec/support/shared_examples/events/validates_date_string.rb
+++ b/spec/support/shared_examples/events/validates_date_string.rb
@@ -75,4 +75,25 @@ RSpec.shared_examples "validates date string" do |attribute, model_name, options
     model.valid?
     expect(model.errors.messages).to eq(dates: ["contained some dates unreasonably far in the future: 02/06/2014"])
   end
+
+  it "is invalid with duplicate dates" do
+    model = build(model_name, dates: "12/07/2012,12/07/2012")
+    model.valid?
+    expect(model.errors.messages).to eq(dates: ["contained some dates more than once: 12/07/2012"])
+  end
+
+  it "only reports duplicate future dates once as future" do
+    model = build(model_name, dates: "01/02/2020,01/02/2020")
+    model.valid?
+    expect(model.errors.messages).to eq(
+      dates: ["contained some dates unreasonably far in the future: 01/02/2020",
+              "contained some dates more than once: 01/02/2020"]
+    )
+  end
+
+  it "reports duplicated non-dates twice" do
+    model = build(model_name, dates: "30/02/2012,30/02/2012")
+    model.valid?
+    expect(model.errors.messages).to eq(dates: ['contained some invalid dates: "30/02/2012", "30/02/2012"'])
+  end
 end


### PR DESCRIPTION
In the scenario where a user adds eg:

12/02/2024,12/02/2024

… that’s probably a mistake - maybe they meant to add:

12/02/2024,12/03/2024

…so we should show a validation error.

Use a Set since it's optimised for uniqueness so is much faster to call
include? on - significant since include will get called n times.

We still end up double-reporting invalid dates, but that's no big deal.