### PR TITLE
Declare CSS build dependency: javascript:install

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,3 @@ are not included in the .env.example file:
   - `CANONICAL_HOST` - all variations of the domain will be `301` redirected
     to this - eg. set it to `www.swingoutlondon.co.uk` to have
     `swingoutlondon.co.uk` redirect to www.
-
-## Heroku setup
-
-When deployed on Heroku, the build environment (eg. staging) needs the Nodejs
-buildpack in addition to the Ruby buildpack:
-
-    heroku buildpacks:add heroku/nodejs -i 1
-
-  https://devcenter.heroku.com/articles/ruby-support#node-js-support

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+task "dartsass:build" => "javascript:install"


### PR DESCRIPTION
Suggested by @nevans as a fix for the build issue described in 5c0fa04

Basically the issue is that we need js to be available before the CSS
build, since the CSS bundle refers to files in node_modules.

This is currently being fixed by adding a node buildpack before the Ruby
buildpack, but that feels like overkill and shouldn't be required - it
also adds a little time to the build since it installs node and yarn (?)
rather than using the system versions (which I think will almost always
be enough for this project?), despite the warnings from Heroku in the
build log:

    ###### WARNING:
       Installing a default version (1.22.19) of Yarn
       This version is not pinned and can change over time, causing unexpected failures.

       Heroku recommends placing the `heroku/nodejs` buildpack in front of the `heroku/ruby`
       buildpack as it offers more comprehensive Node.js support, including the ability to
       customise the Node.js version:

       https://devcenter.heroku.com/articles/ruby-support#node-js-support
    ###### WARNING:
       Installing a default version (20.9.0) of Node.js.
       This version is not pinned and can change over time, causing unexpected failures.

       Heroku recommends placing the `heroku/nodejs` buildpack in front of
       `heroku/ruby` to install a specific version of node:

       https://devcenter.heroku.com/articles/ruby-support#node-js-support