### PR TITLE
Refactor: occasional means frequency == 0

### DIFF
--- a/app/concerns/frequency.rb
+++ b/app/concerns/frequency.rb
@@ -8,6 +8,6 @@ module Frequency
   def infrequent?
     return false if frequency.nil?
 
-    frequency.zero? || frequency >= 4
+    frequency.zero?
   end
 end

--- a/app/controllers/occasional_events_controller.rb
+++ b/app/controllers/occasional_events_controller.rb
@@ -6,7 +6,7 @@ class OccasionalEventsController < CmsBaseController
   def index
     @today = SOLDNTime.today
 
-    event_finder = ->(date) { Event.less_frequent_socials_on(date).includes(:venue) }
+    event_finder = ->(date) { Event.occasional_socials_on(date).includes(:venue) }
     dates = SOLDNTime.listing_dates(number_of_days: 6.months.in_days)
     @socials_dates = SocialsListings.new(event_finder:, presenter_class: OccasionalSocialListing).build(dates)
     @last_updated = LastUpdated.new

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -42,13 +42,13 @@ class Event < ApplicationRecord
   class << self
     def socials_on_date(date)
       result = weekly_socials_on(date).includes(:venue)
-      result += non_weekly_socials_on(date).includes(:venue)
+      result += occasional_socials_on(date).includes(:venue)
       result
     end
 
     def socials_on_date_for_venue(date, venue)
       result = weekly_socials_on(date).where(venue_id: venue.id)
-      result += non_weekly_socials_on(date).where(venue_id: venue.id)
+      result += occasional_socials_on(date).where(venue_id: venue.id)
       result
     end
 
@@ -56,18 +56,11 @@ class Event < ApplicationRecord
       weekly.socials.active_on(date).on_same_day_of_week(date)
     end
 
-    def non_weekly_socials_on(date)
+    def occasional_socials_on(date)
       swing_date = SwingDate.find_by(date:)
       return none unless swing_date
 
-      swing_date.events.socials
-    end
-
-    def less_frequent_socials_on(date)
-      swing_date = SwingDate.find_by(date:)
-      return none unless swing_date
-
-      swing_date.events.socials.less_frequent
+      swing_date.events.occasional.socials
     end
 
     def cancelled_on_date(date)
@@ -114,7 +107,7 @@ class Event < ApplicationRecord
   scope :socials, -> { where(has_social: true) }
   scope :weekly, -> { where(frequency: 1) }
   scope :weekly_or_fortnightly, -> { where(frequency: [1, 2]) }
-  scope :less_frequent, -> { where(frequency: 0).or(where(frequency: 4..52)) }
+  scope :occasional, -> { where(frequency: 0) }
 
   scope :active, -> { where("last_date IS NULL OR last_date > ?", Date.current) }
   scope :ended, -> { where("last_date IS NOT NULL AND last_date < ?", Date.current) }

--- a/spec/forms/create_event_form_spec.rb
+++ b/spec/forms/create_event_form_spec.rb
@@ -68,18 +68,6 @@ RSpec.describe CreateEventForm do
       expect(form.infrequent?).to be true
     end
 
-    it "is true if frequency is 4" do
-      form = described_class.new(frequency: 4)
-
-      expect(form.infrequent?).to be true
-    end
-
-    it "is true if frequency is more than 4" do
-      form = described_class.new(frequency: 5)
-
-      expect(form.infrequent?).to be true
-    end
-
     it "is false if frequency is 1" do
       form = described_class.new(frequency: 1)
 

--- a/spec/services/socials_listings_integration_spec.rb
+++ b/spec/services/socials_listings_integration_spec.rb
@@ -104,9 +104,9 @@ RSpec.describe SocialsListings do
 
           # included events:
           create(:intermittent_social, dates: [date(1)], title: "Tomorrow")
-          create(:social, frequency: 4, dates: [date(10), date(11)], title: "Twice")
-          create(:social, frequency: 4, dates: [date(8)], title: "Shown last")
-          create(:social, frequency: 2, dates: [date(8)], title: "Shown first")
+          create(:intermittent_social, dates: [date(10), date(11)], title: "Twice")
+          create(:intermittent_social, dates: [date(8)], title: "Shown last")
+          create(:intermittent_social, dates: [date(8)], title: "Shown first")
 
           dates = SOLDNTime.listing_dates(Time.zone.today)
           result = described_class.new(presenter_class: test_presenter).build(dates)


### PR DESCRIPTION
All new events are weekly (frequency 1) or occasional (frequency 0).

There are still events with a frequency of 2, 4 or more, but they can't
be saved without changing the frequency.

I guess previously we've been assuming that any event with dates must be
occasional, and that's hopefully true, but this change makes things more
explicit, and in any case, if an event is weekly and has dates, that
should be considered invalid data.