### PR TITLE
Remove elabs-matchers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,6 @@ end
 group :test do
   gem "capybara"
   gem "climate_control"
-  gem "elabs_matchers"
   gem "launchy"
   gem "rails-controller-testing" # TODO: refactor tests so that we don't need this
   gem "selenium-webdriver", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,9 +121,6 @@ GEM
       railties (>= 3.2)
     drb (2.2.0)
       ruby2_keywords
-    elabs_matchers (2.0.1)
-      rspec-core
-      rspec-expectations
     erubi (1.12.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -430,7 +427,6 @@ DEPENDENCIES
   dalli
   dartsass-rails
   dotenv-rails
-  elabs_matchers
   factory_bot_rails
   faker
   geocoder

--- a/spec/system/admins_can_clear_the_cache_spec.rb
+++ b/spec/system/admins_can_clear_the_cache_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Admins can clear the cache" do
     click_link "Cache"
     click_button "Clear"
 
-    expect(page).to have_header("Events")
+    expect(page).to have_content("Events")
     expect(Rails.cache.read("a_cache_key")).to be_nil
   end
 

--- a/spec/system/editors_can_disable_account_spec.rb
+++ b/spec/system/editors_can_disable_account_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Editor Login Revocation" do
       click_button "Disable my login"
     end
 
-    expect(page).to have_header("Editor Login")
+    expect(page).to have_content("Editor Login")
     expect(page).to have_content("Your login permissions have been revoked in Facebook")
     expect(page).to have_button("Log in")
 

--- a/spec/system/editors_can_login_spec.rb
+++ b/spec/system/editors_can_login_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe "Editor Login" do
 
     visit "/events/new"
 
-    expect(page).not_to have_header("New event")
+    expect(page).not_to have_content("New event")
 
     click_button "Log in"
 
-    expect(page).to have_header("New event")
+    expect(page).to have_content("New event")
     expect(page).to have_content("Al Minns")
   end
 
@@ -26,11 +26,11 @@ RSpec.describe "Editor Login" do
 
     visit "/events"
 
-    expect(page).not_to have_header("Events")
+    expect(page).not_to have_content("Events")
 
     click_button "Log in"
 
-    expect(page).to have_header("Events")
+    expect(page).to have_content("Events")
     expect(page).to have_content("Herbert White (Admin)")
   end
 
@@ -46,7 +46,7 @@ RSpec.describe "Editor Login" do
       expect(page).to have_content(
         "Your Facebook ID for Swing Out London (76543210987654321) isn't in the approved list"
       )
-      expect(page).not_to have_header("Events")
+      expect(page).not_to have_content("Events")
     end
   end
 
@@ -59,7 +59,7 @@ RSpec.describe "Editor Login" do
       click_button "Log in"
 
       expect(page).to have_content("There was a problem with your login to Facebook")
-      expect(page).not_to have_header("Events")
+      expect(page).not_to have_content("Events")
     end
   end
 
@@ -70,11 +70,11 @@ RSpec.describe "Editor Login" do
 
       visit "/login"
 
-      expect(page).not_to have_header("Events")
+      expect(page).not_to have_content("Events")
 
       click_button "Log in"
 
-      expect(page).to have_header("Events")
+      expect(page).to have_content("Events")
       expect(page).to have_content("Al Minns")
     end
   end


### PR DESCRIPTION
I know some of the matchers are buggy, and generally I'm no longer a fan of the approach. I don't think it's worth the cost of an extra dependency.