### PR TITLE
Include sitemap in Robots.txt

### DIFF
--- a/app/controllers/robots_controller.rb
+++ b/app/controllers/robots_controller.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 
 class RobotsController < ActionController::Base # rubocop:disable Rails/ApplicationController
+  def index
+    respond_to :text
+    expires_in 6.hours, public: true
+
+    canonical_sitemap_url = sitemap_url(host: ENV.fetch("CANONICAL_HOST"), protocol: "https")
+
+    render "index", locals: { canonical_sitemap_url: }
+  end
+
   def no_content
     head :no_content
   end

--- a/app/views/robots/index.text.erb
+++ b/app/views/robots/index.text.erb
@@ -13,3 +13,6 @@ Disallow: /map/classes/*
 
 User-agent: BLEXBot
 Disallow: /
+
+Sitemap: <%= canonical_sitemap_url %>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ Rails.application.routes.draw do
 
   resource :audit_log, only: %i[show]
 
+  get "robots.txt", to: "robots#index", format: "txt"
   get "sitemap", to: "sitemaps#index", defaults: { format: "xml" }
 
   get "apple-touch-icon-precomposed" => "application#not_found"

--- a/spec/requests/robots_spec.rb
+++ b/spec/requests/robots_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "robots.txt" do
+  around do |example|
+    ClimateControl.modify(CANONICAL_HOST: "www.swingoutlondon.co.uk") { example.run }
+  end
+
+  it "blocks robots from /login" do
+    get "/robots.txt"
+    expect(response.body).to include "Disallow: /login"
+  end
+
+  it "includes a link to the sitemap" do
+    get "/robots.txt"
+    expect(response.body).to include "Sitemap: https://www.swingoutlondon.co.uk"
+  end
+
+  it "returns the correct file type" do
+    get "/robots.txt"
+    expect(response.headers["Content-Type"]).to include "text/plain"
+  end
+
+  it "can be publicly cached" do
+    get "/robots.txt"
+    expect(response.headers["Cache-Control"]).to include "public"
+  end
+
+  it "can be cached for 6 hours" do
+    get "/robots.txt"
+    expect(response.headers["Cache-Control"]).to include "max-age=21600" # 6 hours in seconds
+  end
+end


### PR DESCRIPTION
We get requests form bots for sitemaps at different URLs sometimes.
Let's mitigate that by telling them where to expect to find it.

The challenge is that we need a different URL for London and Bristol, so
to support this, the robots txt needs to be dynamic, but let's ensure
that it's cached and publicly cacheable by intermediate proxies
(whatever those are).