### PR TITLE
Redirect requests for sitemaps

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,8 @@ Rails.application.routes.draw do
 
   get "robots.txt", to: "robots#index", format: "txt"
   get "sitemap", to: "sitemaps#index", defaults: { format: "xml" }
+  get "sitemap_index.xml", to: redirect("/sitemap.xml"), status: 301
+  get "sitemap.xml.gz", to: redirect("/sitemap.xml"), status: 301
 
   get "apple-touch-icon-precomposed" => "application#not_found"
   get "apple-touch-icon-:size-precomposed" => "application#not_found"

--- a/spec/requests/sitemap_spec.rb
+++ b/spec/requests/sitemap_spec.rb
@@ -21,6 +21,24 @@ RSpec.describe "Sitemaps" do
     expect(response).to have_http_status(:ok)
   end
 
+  it "redirects requests for sitemap_index" do
+    get "/sitemap_index.xml"
+
+    aggregate_failures do
+      expect(response).to redirect_to("/sitemap.xml")
+      expect(response).to have_http_status(:moved_permanently)
+    end
+  end
+
+  it "redirects requests for sitemap.xml.gz" do
+    get "/sitemap.xml.gz"
+
+    aggregate_failures do
+      expect(response).to redirect_to("/sitemap.xml")
+      expect(response).to have_http_status(:moved_permanently)
+    end
+  end
+
   it "doesn't respond to other formats" do
     get "/sitemap.txt"
 


### PR DESCRIPTION
We keep getting requests for these URLs from BingBot, despite what
Robots.txt says, so let's redirect them and save some space in our error
logging.