### PR TITLE
Set an enum for Event#day

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -34,6 +34,8 @@ class Event < ApplicationRecord
   validates_with ValidSocialOrClass
   validates_with ValidWeeklyEvent
 
+  enum day: DAYNAMES.index_by { _1 }
+
   strip_attributes only: %i[title url]
 
   class << self

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -144,6 +144,21 @@ RSpec.describe Event do
     it { is_expected.to validate_uniqueness_of(:organiser_token).allow_nil }
   end
 
+  describe "day" do
+    it "is an enum" do
+      expect(described_class.new).to define_enum_for(:day)
+        .with_values(
+          "Monday" => "Monday",
+          "Tuesday" => "Tuesday",
+          "Wednesday" => "Wednesday",
+          "Thursday" => "Thursday",
+          "Friday" => "Friday",
+          "Saturday" => "Saturday",
+          "Sunday" => "Sunday"
+        ).backed_by_column_of_type(:string)
+    end
+  end
+
   describe "#future_dates?" do
     context "when the event has no dates" do
       it "is false" do

--- a/spec/system/editors_can_edit_events_spec.rb
+++ b/spec/system/editors_can_edit_events_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe "Editors can edit events", :js do
 
     expect(page).to have_content("Last updated by Al Minns (12345678901234567) on Friday 2nd January 2015 at 23:17:16")
     audit = Audit.last
-    expect(audit.audited_changes).to eq("day" => [nil, ""], "class_style" => [nil, ""])
+    expect(audit.audited_changes).to eq("class_style" => [nil, ""])
     expect(audit.comment).to eq "Updated dates: (old: 12/12/2012,13/12/2012) (new: 12/12/2012,12/01/2013)"
   end
 
@@ -135,7 +135,7 @@ RSpec.describe "Editors can edit events", :js do
 
     expect(page).to have_content("Last updated by Al Minns (12345678901234567) on Friday 2nd January 2015 at 23:17:16")
     audit = Audit.last
-    expect(audit.audited_changes).to eq("day" => [nil, ""], "class_style" => [nil, ""])
+    expect(audit.audited_changes).to eq("class_style" => [nil, ""])
     expect(audit.comment).to eq "Updated cancellations: (old: ) (new: 12/12/2012)"
   end
 


### PR DESCRIPTION
This feels enough: since the user is picking from a select box, not
entering a value, so they can't recover. For that reason it feels
appropriate to get an ArgumentError rather than a validation error.

Note that the change in the Audit logs in specs is because now day will
be saved as nil, while currently it's always stored as an empty string.

Not sure if it's a bad idea to have an enum where the keys and values
are the same, but I can't see a reason why.