### PR TITLE
Update Facebook share button src url

### DIFF
--- a/app/views/listings/_facebook_buttons.html.erb
+++ b/app/views/listings/_facebook_buttons.html.erb
@@ -4,7 +4,7 @@
     var js, fjs = d.getElementsByTagName(s)[0];
     if (d.getElementById(id)) return;
     js = d.createElement(s); js.id = id;
-    js.src = "//connect.facebook.net/en_US/all.js#xfbml=1";
+    js.src = "https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v3.0";
     fjs.parentNode.insertBefore(js, fjs);
   }(document, 'script', 'facebook-jssdk'));
 </script>


### PR DESCRIPTION
Got some odd routing errors - maybe //connect means "use the scheme of
the main website when requesting this", and some browsers can't handle
that and were instead trying to request it as a relative URL? Using a
full URL feels better in any case:

  https://developers.facebook.com/docs/plugins/share-button/#example