### PR TITLE
Fix Locale issues

### DIFF
--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+I18n.available_locales = [:en]

--- a/config/locales/en.rb
+++ b/config/locales/en.rb
@@ -12,20 +12,20 @@ end
   en: {
     time: {
       formats: {
-        audit_timestamp: lambda { |date|
+        audit_timestamp: lambda { |date, _options = {}|
           date.strftime("on #{human_date(date)} %Y at %H:%M:%S") # on Tuesday 5th December 2017 at 13:08:28
         },
-        last_updated: lambda { |date|
+        last_updated: lambda { |date, _options = {}|
           date.strftime("at %H:%M on #{human_date(date)}") # at 01:04 on Saturday 2nd December
         }
       }
     },
     date: {
       formats: {
-        short: lambda { |date|
+        short: lambda { |date, _options = {}|
           date.strftime("#{ordinal_day(date)} %b")
         },
-        listing_date: lambda { |date|
+        listing_date: lambda { |date, _options = {}|
           date.strftime(human_date(date)) # Monday 4th December
         }
       }


### PR DESCRIPTION
In production we have

    config.i18n.fallbacks = true

...which for some reason results in this getting passed as a second
parameter to the lambdas:

    {:fallback_original_locale=>:en}

I guess because maybe we're not explicitly setting locale? Is Rails
automatically setting the locale based on the browser settings? Doesn't
entirely make sense.

Also set the available locales to :en - this is already how it is on
staging (not sure how - maybe heroku does it?), but locally _all_ the
locales seem to be available by default.