### PR TITLE
Update specs: cancel on create is now supported

### DIFF
--- a/spec/services/socials_listings_integration_spec.rb
+++ b/spec/services/socials_listings_integration_spec.rb
@@ -108,8 +108,7 @@ RSpec.describe SocialsListings do
         create(:intermittent_social, dates: [date(1)], title: "Tomorrow")
         create(:intermittent_social, dates: [date(10), date(11)], title: "Twice")
         create(:intermittent_social, dates: [date(8)], title: "Shown last")
-        event_on_same_date = create(:intermittent_social, title: "Shown first")
-        EventUpdater.new(event_on_same_date).update!(dates: [date(8)])
+        create(:intermittent_social, dates: [date(8)], title: "Shown first") # Alphabetical
 
         dates = SOLDNTime.listing_dates(Time.zone.today)
         result = described_class.new(presenter_class: test_presenter).build(dates)

--- a/spec/system/editors_can_create_events_spec.rb
+++ b/spec/system/editors_can_create_events_spec.rb
@@ -33,8 +33,7 @@ RSpec.describe "Editors can create events", :js do
 
       choose "Monthly or occasionally"
       fill_in "Upcoming dates", with: "12/12/2012, 19/12/2012"
-      # TODO: Make this work:
-      # fill_in 'Cancelled dates', with: '12/12/2012'
+      fill_in "Cancelled dates", with: "12/12/2012"
       fill_in "First date", with: "12/12/2012"
       fill_in "Last date", with: "19/12/2012"
 
@@ -50,7 +49,7 @@ RSpec.describe "Editors can create events", :js do
         .and have_content("Class style:\nBalboa")
         .and have_content("Frequency:\nMonthly or occasionally")
         .and have_content("Dates:\n12/12/2012, 19/12/2012")
-        .and have_content("Cancelled:\nNone")
+        .and have_content("Cancelled:\n12/12/2012")
         .and have_content("First date:\nWednesday 12th December")
         .and have_content("Last date:\nWednesday 19th December")
         .and have_content("Url:\nhttp://www.lsds.co.uk/stompin")


### PR DESCRIPTION
Previously we weren't able to mark an event as cancelled when creating,
since cancellation looked for an existing SwingDate record (?). Now that
we're using EventInstances we can take a more direct approach.