### PR TITLE
Use show_exceptions = :rescuable

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = :none
+  config.action_dispatch.show_exceptions = :rescuable
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/spec/system/organisers_can_edit_events_spec.rb
+++ b/spec/system/organisers_can_edit_events_spec.rb
@@ -147,7 +147,9 @@ RSpec.describe "Organisers can edit events" do
 
   context "when the organiser token is incorrect" do
     it "renders a 404" do
-      expect { visit("/external_events/abc123/edit") }.to raise_error(ActiveRecord::RecordNotFound)
+      visit("/external_events/abc123/edit")
+
+      expect(page).to have_content("The page you were looking for doesn't exist")
     end
   end
 end


### PR DESCRIPTION
This renders errors in test in the same way that they are in production,
so we can test in a more natural way. I'm surprised there's only one
example, but this still feels like the right way to go.