### PR TITLE
Flashes disappear after 3 seconds

### DIFF
--- a/app/javascript/controllers/flash_controller.js
+++ b/app/javascript/controllers/flash_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Connects to data-controller="flash"
+export default class extends Controller {
+  connect() {
+    this.fadeOutAfterDelay();
+  }
+
+  fadeOutAfterDelay() {
+    setTimeout(() => {
+      this.element.style.transition = 'opacity 1s';
+      this.element.style.opacity = '0';
+      setTimeout(() => { this.element.style.display = 'none' }, 1000); // stop taking up space after it's faded out
+      this
+    }, 3000); // 3 seconds delay
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,5 +7,8 @@ import { application } from "./application"
 import EventFormController from "./event_form_controller"
 application.register("event-form", EventFormController)
 
+import FlashController from "./flash_controller"
+application.register("flash", FlashController)
+
 import OrganiserLinkController from "./organiser_link_controller"
 application.register("organiser-link", OrganiserLinkController)

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,3 +1,3 @@
 <% flash.each do |key, message| %>
-  <%= content_tag :div, message, class: key %>
+  <%= content_tag :div, message, class: key, data: { controller: "flash" } %>
 <% end %>


### PR DESCRIPTION
This is particularly significant for the external events form: since 
there's no redirect, the flash doesn't otherwise disappear, so there's no
feedback that updates happened after the first one.