### PR TITLE
Update Facebook like code

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,10 @@
 # You'll also need to add the URL of the app in the facebook developers dashboard
 FACEBOOK_SECRET=
 
+# FACEBOOK_APP_ID is required for the Facebook Like and Share buttons.
+# We have an app for login which can be used here.
+FACEBOOK_APP_ID=
+
 # Get this by signing up for a google cloud account:
 # https://developers.google.com/maps/documentation/javascript/tutorial
 GOOGLE_MAPS_JAVASCRIPT_API_KEY=

--- a/app/views/listings/_facebook_buttons.html.erb
+++ b/app/views/listings/_facebook_buttons.html.erb
@@ -1,16 +1,6 @@
 <div id="fb-root"></div>
-<script>
-  (function(d, s, id) {
-    var js, fjs = d.getElementsByTagName(s)[0];
-    if (d.getElementById(id)) return;
-    js = d.createElement(s); js.id = id;
-    js.src = "https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v3.0";
-    fjs.parentNode.insertBefore(js, fjs);
-  }(document, 'script', 'facebook-jssdk'));
-</script>
+<script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_GB/sdk.js#xfbml=1&version=v18.0&appId=<%= facebook_app_id %>" nonce="DsyYd9vs"></script>
 
-<%= link_to text,
-  url,
-  class: "fb-like",
-  data: { action: "like", share: "true", layout: "button_count", font: "trebuchet ms" }
-%>
+<div class="fb-like" data-href="<%= url %>" data-layout="button", data-share="true">
+  <%= text %>
+</div>

--- a/app/views/listings/_navigation.html.erb
+++ b/app/views/listings/_navigation.html.erb
@@ -26,9 +26,9 @@
 <div id="soldn_on_the_web">
   <%= render 'advert', advert: ad %>
 
-  <% if CITY.has_facebook_page? %>
+  <% if CITY.has_facebook_page? && ENV.fetch("FACEBOOK_APP_ID", false) %>
     <div id="social_links">
-      <%= render 'facebook_buttons', text: "Like #{tc("site_name")} on Facebook", url: tc("site_url") %>
+      <%= render 'facebook_buttons', text: "Like #{tc("site_name")} on Facebook", url: tc("site_url"), facebook_app_id: ENV.fetch("FACEBOOK_APP_ID") %>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
This doesn't seem to actually fix the Facebook like button (it breaks in
Chrome because of an issue with iFrames?) but it renders the same thing
in a much more terse way.

Switch to the button layout: button-count incorrectly reports 1.1k
people have liked, but actually it's more like 5k