### PR TITLE
Remove Facebook like button

### DIFF
--- a/app/views/listings/_facebook_buttons.html.erb
+++ b/app/views/listings/_facebook_buttons.html.erb
@@ -1,6 +1,0 @@
-<div id="fb-root"></div>
-<script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_GB/sdk.js#xfbml=1&version=v18.0&appId=<%= facebook_app_id %>" nonce="DsyYd9vs"></script>
-
-<div class="fb-like" data-href="<%= url %>" data-layout="button", data-share="true">
-  <%= text %>
-</div>

--- a/app/views/listings/_navigation.html.erb
+++ b/app/views/listings/_navigation.html.erb
@@ -25,12 +25,6 @@
 
 <div id="soldn_on_the_web">
   <%= render 'advert', advert: ad %>
-
-  <% if CITY.has_facebook_page? && ENV.fetch("FACEBOOK_APP_ID", false) %>
-    <div id="social_links">
-      <%= render 'facebook_buttons', text: "Like #{tc("site_name")} on Facebook", url: tc("site_url"), facebook_app_id: ENV.fetch("FACEBOOK_APP_ID") %>
-    </div>
-  <% end %>
 </div>
 
 <%= render 'shared/header_navigation' %>

--- a/config/initializers/city.rb
+++ b/config/initializers/city.rb
@@ -19,14 +19,14 @@ end
 
 Coordinates = Struct.new(:lat, :lng)
 
-City = Struct.new(:key, :map_config, :opengraph_image, :has_facebook_page?) do
+City = Struct.new(:key, :map_config, :opengraph_image) do
   class << self
     def build_london
       map_config = MapConfig.new(
         center: Coordinates.new(51.526532, -0.087777), # Bar Nightjar
         zoom: 11
       )
-      new(:london, map_config, "swingoutlondon_og.png", true)
+      new(:london, map_config, "swingoutlondon_og.png")
     end
 
     def build_bristol
@@ -34,7 +34,7 @@ City = Struct.new(:key, :map_config, :opengraph_image, :has_facebook_page?) do
         center: Coordinates.new(51.4750364, -2.5659198),
         zoom: 12
       )
-      new(:bristol, map_config, "swingoutbristol_og.png", false)
+      new(:bristol, map_config, "swingoutbristol_og.png")
     end
   end
 


### PR DESCRIPTION
FB like button doesn't work for me anymore - not sure how long it's been

    broken: Refused to display 'https://www.facebook.com/' in a frame
    because it set 'X-Frame-Options' to 'deny'.

Might be related to the GDPR changes around Like buttons, which to be
honest I don't understand:

  https://developers.facebook.com/docs/plugins/like-button/

Also the number reported on the button was 1.1k, which is incorrect (the
likes on the SODLN FB page is more like 5k) - not sure what to make of
that.

Discussed with Chris and decided it's not valuable anymore, so let's
just cut it.