### PR TITLE
Fix date field inputs

### DIFF
--- a/spec/system/editors_can_create_events_spec.rb
+++ b/spec/system/editors_can_create_events_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe "Editors can create events", :js do
       choose "Monthly or occasionally"
       fill_in "Upcoming dates", with: "12/12/2012, 19/12/2012"
       fill_in "Cancelled dates", with: "12/12/2012"
-      fill_in "First date", with: "12/12/2012"
-      fill_in "Last date", with: "19/12/2012"
+      fill_in "First date", with: "2012\t1212"
+      fill_in "Last date", with: "2012\t12/19"
 
       Timecop.freeze(Time.zone.local(2012, 1, 2, 23, 17, 16)) do
         click_button "Create"
@@ -92,8 +92,8 @@ RSpec.describe "Editors can create events", :js do
         .and have_content("Dates contained some dates unreasonably far in the future: 19/12/20121")
 
       fill_in "Upcoming dates", with: "12/12/2012, 30/04/2013"
-      fill_in "First date", with: "12/12/2012"
-      fill_in "Last date", with: "30/04/2013"
+      fill_in "First date", with: "2012\t1212"
+      fill_in "Last date", with: "2013\t0430"
 
       click_button "Create"
 
@@ -209,8 +209,8 @@ RSpec.describe "Editors can create events", :js do
       autocomplete_select "Sunshine Swing", from: "Class organiser"
 
       select "Wednesday", from: "Day"
-      fill_in "First date", with: "16/02/2000"
-      fill_in "Last date", with: "16/02/2020"
+      fill_in "First date", with: "2000\t0216"
+      fill_in "Last date", with: "2020\t0216"
 
       Timecop.freeze(Time.zone.local(2000, 1, 2, 23, 17, 16)) do
         click_button "Create"

--- a/spec/system/editors_can_edit_events_spec.rb
+++ b/spec/system/editors_can_edit_events_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe "Editors can edit events", :js do
     fill_in "Course length", with: ""
 
     choose "Monthly or occasionally"
-    fill_in "First date", with: "10/10/2010"
-    fill_in "Last date", with: "02/12/2011"
+    fill_in "First date", with: "2010\t1010"
+    fill_in "Last date", with: "2011\t1202"
 
     fill_in "Upcoming dates", with: "10/10/2010,10/11/2010, 02/12/2011"
     fill_in "Cancelled dates", with: "02/12/2011" # All cancellations need to be in the upcoming dates.

--- a/spec/system/organisers_can_edit_events_spec.rb
+++ b/spec/system/organisers_can_edit_events_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Organisers can edit events" do
       autocomplete_select "The 100 Club", from: "Venue"
       fill_in "Upcoming dates", with: "12/12/2012, 12/01/2013"
       fill_in "Cancelled dates", with: "12/12/2012"
-      fill_in "Last date", with: "12/01/2013"
+      fill_in "Last date", with: "2013\t0112"
       click_button "Update"
 
       expect(page).to have_content("Event was successfully updated")
@@ -63,7 +63,7 @@ RSpec.describe "Organisers can edit events" do
 
       autocomplete_select "The 100 Club", from: "Venue"
       fill_in "Cancelled dates", with: "12/12/2012"
-      fill_in "Last date", with: "12/01/2013"
+      fill_in "Last date", with: "2013\t0112"
       click_button "Update"
 
       expect(page).to have_content("Event was successfully updated")

--- a/spec/system/smoke_spec.rb
+++ b/spec/system/smoke_spec.rb
@@ -69,8 +69,8 @@ RSpec.describe "Adding a new event", :js do
     choose "Weekly"
     select "Saturday", from: "Day"
     fill_in "Cancelled dates", with: "09/01/1937"
-    fill_in "First date", with: "12/03/1926"
-    fill_in "Last date", with: "11/10/1958"
+    fill_in "First date", with: "1926\t0312"
+    fill_in "Last date", with: "1958\t10/11"
 
     click_button "Create"
 


### PR DESCRIPTION
Looks like this was passing on CI but not on one of my machines (snusmumriken).

Seems like for some reason the year part of date fields needs a tab character afterwards, but month jumps straight to day after two chars have been entered.
