### PR TITLE
Upgrade capybara to version with new headless

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ group :development, :test do
 end
 
 group :test do
-  gem "capybara", github: "teamcapybara/capybara", branch: "master" # remove when new headless is in master (> 3.39.2)
+  gem "capybara", ">= 3.40"
   gem "climate_control"
   gem "launchy"
   gem "selenium-webdriver", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,3 @@
-GIT
-  remote: https://github.com/teamcapybara/capybara.git
-  revision: 52eaecea6d154b7d664b0032cd1cbcad4788fe65
-  branch: master
-  specs:
-    capybara (3.40.0)
-      addressable
-      matrix
-      mini_mime (>= 0.1.3)
-      nokogiri (~> 1.11)
-      rack (>= 1.6.0)
-      rack-test (>= 0.6.3)
-      regexp_parser (>= 1.5, < 3.0)
-      xpath (~> 3.2)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -106,6 +91,15 @@ GEM
     bullet (7.1.4)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
+    capybara (3.40.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.11)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
@@ -420,7 +414,7 @@ DEPENDENCIES
   audited
   bootsnap
   bullet
-  capybara!
+  capybara (>= 3.40)
   climate_control
   dalli
   dartsass-rails


### PR DESCRIPTION
Now we don't need to use master