### PR TITLE
Show facebook auth token expiry on user page

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -12,7 +12,7 @@ class SessionsController < ApplicationController
     if %i[editor admin].include?(role)
       after_login_path = return_to_session.path(fallback: events_path)
       reset_session # calling reset_session prevents "session fixation" attacks
-      login_session.log_in!(auth_id: user.id, name: user.name, token: user.token, role:)
+      login_session.log_in!(auth_id: user.id, name: user.name, token: user.token, token_expires_at: user.expires_at, role:)
       redirect_to after_login_path
     else
       flash.alert = "Your Facebook ID for #{tc('site_name')} (#{user.id}) isn't in the approved list.\n" \

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,9 @@
 class UsersController < CmsBaseController
   layout "cms"
 
-  def show; end
+  def show
+    render locals: { access_token_expires_at: Time.zone.at(login_session.user.token_expires_at) }
+  end
 
   def destroy
     RevokeLogin.new.revoke!(login_session.user)

--- a/app/models/auth_response.rb
+++ b/app/models/auth_response.rb
@@ -2,7 +2,7 @@
 
 class AuthResponse
   def initialize(request_env)
-    @request_env = request_env
+    @auth_hash = request_env.fetch("omniauth.auth")
   end
 
   def id
@@ -14,14 +14,18 @@ class AuthResponse
   end
 
   def token
-    auth_hash.fetch("credentials").fetch("token")
+    credentials.fetch("token")
+  end
+
+  def expires_at
+    credentials.fetch("expires_at")
   end
 
   private
 
-  def auth_hash
-    request_env.fetch("omniauth.auth")
-  end
+  attr_reader :auth_hash
 
-  attr_reader :request_env
+  def credentials
+    auth_hash.fetch("credentials")
+  end
 end

--- a/app/models/login_session.rb
+++ b/app/models/login_session.rb
@@ -6,9 +6,15 @@ class LoginSession
     @logger = logger
   end
 
-  def log_in!(auth_id:, name:, token:, role:)
+  def log_in!(auth_id:, name:, token:, token_expires_at:, role:)
     admin = role == :admin
-    request.session[:user] = { "auth_id" => auth_id, "name" => name, "token" => token, "admin" => admin }
+    request.session[:user] = {
+      "auth_id" => auth_id,
+      "name" => name,
+      "token" => token,
+      "token_expires_at" => token_expires_at,
+      "admin" => admin
+    }
     log_message = "Logged in as auth id #{auth_id}"
     log_message += " with Admin permissions" if admin
     logger.info(log_message)
@@ -65,6 +71,10 @@ class LoginSession
       user.fetch("token")
     end
 
+    def token_expires_at
+      user.fetch("token_expires_at")
+    end
+
     private
 
     attr_reader :user
@@ -93,6 +103,10 @@ class LoginSession
 
     def token
       "NO TOKEN"
+    end
+
+    def token_expires_at
+      0
     end
   end
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,8 @@
 <main class="page account">
   <h1>Account</h1>
+
+  <p>Facebook access token will expire at <%= access_token_expires_at %></p>
+
   <%= button_to 'Log out', logout_path, method: :delete, class: "button" %>
 
   <h2>Revoke login permissions</h2>

--- a/lib/omniauth_test_response_builder.rb
+++ b/lib/omniauth_test_response_builder.rb
@@ -11,11 +11,12 @@ class OmniauthTestResponseBuilder
   def stub_auth_hash(
     id: Faker::Facebook.uid,
     name: Faker::Name.lindy_hop_name,
-    token: SecureRandom.hex
+    token: SecureRandom.hex,
+    expires_at: 60.days.from_now.to_i
   )
     raise "Can't stub authentication in production" if Rails.env.production?
 
-    auth_hash = facebook_auth_hash(id:, name:, token:)
+    auth_hash = facebook_auth_hash(id:, name:, token:, expires_at:)
     mock_auth_config[:facebook] = auth_hash
   end
 
@@ -23,7 +24,7 @@ class OmniauthTestResponseBuilder
 
   attr_reader :hash_builder, :mock_auth_config
 
-  def facebook_auth_hash(id:, name:, token:)
+  def facebook_auth_hash(id:, name:, token:, expires_at:)
     hash_builder.new(
       "provider" => "facebook",
       "uid" => id,
@@ -33,7 +34,7 @@ class OmniauthTestResponseBuilder
       },
       "credentials" => {
         "token" => token,
-        "expires_at" => 1546086985,
+        "expires_at" => expires_at,
         "expires" => true
       },
       "extra" => {

--- a/spec/lib/omniauth_test_response_builder_spec.rb
+++ b/spec/lib/omniauth_test_response_builder_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe OmniauthTestResponseBuilder do
       hash_builder = class_double("OmniAuth::AuthHash", new: auth_hash)
       mock_auth_config = {}
 
-      described_class.new(hash_builder:, mock_auth_config:).stub_auth_hash(id: double, name: double)
+      described_class.new(hash_builder:, mock_auth_config:).stub_auth_hash(id: double, name: double, expires_at: double)
 
       expect(mock_auth_config).to eq(facebook: auth_hash)
     end
@@ -24,7 +24,8 @@ RSpec.describe OmniauthTestResponseBuilder do
       described_class.new(hash_builder:, mock_auth_config:).stub_auth_hash(
         id: 79911749339938642,
         name: "Lauretta Kertzmann",
-        token: "237699305323155|dc16f036399dda7bc8f140701a901a4f"
+        token: "237699305323155|dc16f036399dda7bc8f140701a901a4f",
+        expires_at: 1546086985
       )
 
       expect(hash_builder).to have_received(:new).with(

--- a/spec/lib/omniauth_test_response_builder_spec.rb
+++ b/spec/lib/omniauth_test_response_builder_spec.rb
@@ -5,12 +5,15 @@ require "lib/omniauth_test_response_builder"
 
 RSpec.describe OmniauthTestResponseBuilder do
   describe "#stub_auth_hash" do
+    before { stub_const("Rails", double(env: double(production?: false))) } # rubocop:disable RSpec/VerifiedDoubles
+
     it "configures Omniauth to return a fixed hash from all requests" do
       auth_hash = instance_double("OmniAuth::AuthHash")
       hash_builder = class_double("OmniAuth::AuthHash", new: auth_hash)
       mock_auth_config = {}
 
-      described_class.new(hash_builder:, mock_auth_config:).stub_auth_hash
+      described_class.new(hash_builder:, mock_auth_config:).stub_auth_hash(id: double, name: double)
+
       expect(mock_auth_config).to eq(facebook: auth_hash)
     end
 

--- a/spec/models/auth_response_spec.rb
+++ b/spec/models/auth_response_spec.rb
@@ -84,4 +84,31 @@ RSpec.describe AuthResponse do
       expect(response.token).to eq "0469a691b47c1df413e95edabd336ca3"
     end
   end
+
+  describe "#expires_at" do
+    it "returns the token expiry timestamp from the auth hash" do
+      request_env = {
+        "omniauth.auth" => {
+          "provider" => "facebook",
+          "uid" => "72432833316128378",
+          "info" => {
+            "name" => "Felipe Goyette Jr.",
+            "image" => "http://graph.facebook.com/v2.10/72432833316128378/picture"
+          },
+          "credentials" => {
+            "token" => "0469a691b47c1df413e95edabd336ca3",
+            "expires_at" => 1546086985,
+            "expires" => true
+          },
+          "extra" => {
+            "raw_info" => { "name" => "72432833316128378", "id" => "72432833316128378" }
+          }
+        }
+      }
+
+      response = described_class.new(request_env)
+
+      expect(response.expires_at).to eq 1546086985
+    end
+  end
 end

--- a/spec/system/editors_can_login_spec.rb
+++ b/spec/system/editors_can_login_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Editor Login" do
   include FacebookHelper
 
   it "Editors can login and access editor pages" do
-    stub_auth_hash(id: 12345678901234567, name: "Al Minns")
+    stub_auth_hash(id: 12345678901234567, name: "Al Minns", expires_at: 1709166148)
     stub_facebook_config(editor_user_ids: [12345678901234567], admin_user_ids: [])
 
     visit "/events/new"
@@ -18,6 +18,10 @@ RSpec.describe "Editor Login" do
 
     expect(page).to have_content("New event")
     expect(page).to have_content("Al Minns")
+
+    click_on "Al Minns"
+
+    expect(page).to have_content("Facebook access token will expire at 2024-02-29 00:22:28 +0000")
   end
 
   it "Admins can login and access editor pages" do


### PR DESCRIPTION
This isn't really useful, but it verifies that we have a 60 day token, so
Omniauth is indeed dealing with exchanging the initial short-lived auth
token for a longer lived token.