### PR TITLE
Display FB access token expiry in words

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,7 @@ class UsersController < CmsBaseController
   layout "cms"
 
   def show
-    render locals: { access_token_expires_at: Time.zone.at(login_session.user.token_expires_at) }
+    render locals: { access_token_expiry: AccessTokenExpiry.new(user: login_session.user) }
   end
 
   def destroy

--- a/app/presenters/access_token_expiry.rb
+++ b/app/presenters/access_token_expiry.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class AccessTokenExpiry
+  include ActionView::Helpers::TextHelper
+
+  def initialize(user:, now_in_seconds: Time.current.to_i)
+    @expiry_time = user.token_expires_at
+    @now_in_seconds = now_in_seconds
+  end
+
+  def offset_string
+    case status
+    in :active
+      "will expire in #{pluralize(days_offset, 'day')}"
+    in :expired
+      "has expired"
+    end
+  end
+
+  private
+
+  def days_offset
+    ((expiry_time - now_in_seconds) / 86_400.0).ceil # 86400 = 1 day in seconds
+  end
+
+  def status
+    if days_offset.positive?
+      :active
+    else
+      :expired
+    end
+  end
+
+  attr_reader :expiry_time, :now_in_seconds
+end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,9 +1,11 @@
 <main class="page account">
   <h1>Account</h1>
 
-  <p>Facebook access token will expire at <%= access_token_expires_at %></p>
-
   <%= button_to 'Log out', logout_path, method: :delete, class: "button" %>
+
+  <h2>Facebook Graph API Access Token</h2>
+
+  <p>Your Facebook access token <%= access_token_expiry.offset_string %></p>
 
   <h2>Revoke login permissions</h2>
 

--- a/spec/presenters/access_token_expiry_spec.rb
+++ b/spec/presenters/access_token_expiry_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "action_view"
+require "action_view/helpers" # for pluralize
+require "app/presenters/access_token_expiry"
+
+RSpec.describe AccessTokenExpiry do
+  describe AccessTokenExpiry do
+    describe "#offset_string" do
+      context "when the expiry time is exactly 60 days in the future (max life of a FB token)" do
+        it "returns an expiry message" do
+          user = instance_double("LoginSession::User", token_expires_at: (1709475483 + 5184000)) # 5184000 = 60 days
+          now_in_seconds = 1709475483 # 1709475483 = 2024-03-03 15:18:03 +0100
+          presenter = described_class.new(user:, now_in_seconds:)
+
+          expect(presenter.offset_string).to eq("will expire in 60 days")
+        end
+      end
+
+      context "when the expiry time is slightly less than 60 days in the future (max life of a FB token)" do
+        it "still says 60 days" do
+          user = instance_double("LoginSession::User", token_expires_at: (1709475483 + 5183999)) # 5183999
+          now_in_seconds = 1709475483 # 1709475483 = 2024-03-03 15:18:03 +0100
+          presenter = described_class.new(user:, now_in_seconds:)
+
+          expect(presenter.offset_string).to eq("will expire in 60 days")
+        end
+      end
+
+      context "when the expiry time is tomorrow" do
+        it "returns an expiry message" do
+          user = instance_double("LoginSession::User", token_expires_at: (1709475483 + 86400)) # 86400 = 1 day
+          now_in_seconds = 1709475483 # 1709475483 = 2024-03-03 15:18:03 +0100
+          presenter = described_class.new(user:, now_in_seconds:)
+
+          expect(presenter.offset_string).to eq("will expire in 1 day")
+        end
+      end
+
+      context "when the expiry time is in less than 24 hours" do
+        it "returns an expiry message" do
+          user = instance_double("LoginSession::User", token_expires_at: (1709475483 + 43200)) # 43200 = 12 hours
+          now_in_seconds = 1709475483 # 1709475483 = 2024-03-03 15:18:03 +0100
+          presenter = described_class.new(user:, now_in_seconds:)
+
+          expect(presenter.offset_string).to eq("will expire in 1 day") # a little ambiguous, but close enough
+        end
+      end
+
+      context "when the expiry time is in the past" do
+        it "returns an expiry message" do
+          user = instance_double("LoginSession::User", token_expires_at: (1709475483 - 86400)) # 86400 = 1 day
+          now_in_seconds = 1709475483 # 1709475483 = 2024-03-03 15:18:03 +0100
+          presenter = described_class.new(user:, now_in_seconds:)
+
+          expect(presenter.offset_string).to eq("has expired")
+        end
+      end
+
+      context "when the expiry time is less than 24 hours ago" do
+        it "returns an expiry message" do
+          user = instance_double("LoginSession::User", token_expires_at: (1709475483 - 43200)) # 43200 = 12 hours
+          now_in_seconds = 1709475483 # 1709475483 = 2024-03-03 15:18:03 +0100
+          presenter = described_class.new(user:, now_in_seconds:)
+
+          expect(presenter.offset_string).to eq("has expired")
+        end
+      end
+    end
+  end
+end

--- a/spec/system/editors_can_login_spec.rb
+++ b/spec/system/editors_can_login_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Editor Login" do
   include FacebookHelper
 
   it "Editors can login and access editor pages" do
-    stub_auth_hash(id: 12345678901234567, name: "Al Minns", expires_at: 1709166148)
+    stub_auth_hash(id: 12345678901234567, name: "Al Minns", expires_at: 60.days.from_now.to_i)
     stub_facebook_config(editor_user_ids: [12345678901234567], admin_user_ids: [])
 
     visit "/events/new"
@@ -21,7 +21,7 @@ RSpec.describe "Editor Login" do
 
     click_on "Al Minns"
 
-    expect(page).to have_content("Facebook access token will expire at 2024-02-29 00:22:28 +0000")
+    expect(page).to have_content("Facebook access token will expire in 60 days")
   end
 
   it "Admins can login and access editor pages" do


### PR DESCRIPTION
This is not entirely accurate: in the 0 case, we know that the token
will expire within 24 hours of now, which could be today or tomorrow.

We could make this more accurate by getting the actual Date objects
associated with these timestamps and comparing those, but I'm not sure
it's worth it? The nice thing about just doing numeric comparisons is
that this object is nice and simple and doesn't need to know about time
zone.