### PR TITLE
Fix: don't allow editing freq for weekly class

### DIFF
--- a/app/forms/edit_event_form.rb
+++ b/app/forms/edit_event_form.rb
@@ -99,14 +99,14 @@ class EditEventForm
     date_parser.parse(cancellations)
   end
 
+  def type_is_weekly_class?
+    event_type == "weekly_class"
+  end
+
   private
 
   def type_is_social_dance?
     event_type == "social_dance"
-  end
-
-  def type_is_weekly_class?
-    event_type == "weekly_class"
   end
 
   def has_weekly_class? # rubocop:disable Naming/PredicateName

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -88,10 +88,13 @@
         <%= f.radio_button(:frequency, 1, data: { action: "event-form#setWeekly", "event-form-target" => "frequencyWeekly" }) %>
         Weekly
       </label>
-      <label>
-        <%= f.radio_button(:frequency, 0, data: { action: "event-form#setInfrequently" }) %>
-        Monthly or occasionally
-      </label>
+
+      <% unless (@form.persisted? && @form.type_is_weekly_class?) %>
+        <label>
+          <%= f.radio_button(:frequency, 0, data: { action: "event-form#setInfrequently" }) %>
+          Monthly or occasionally
+        </label>
+      <% end %>
       <% if @form.persisted? && [0, 1].exclude?(@form.frequency) %>
         <p class="help">Legacy frequency: <%= @form.frequency %></p>
       <% end %>

--- a/spec/forms/edit_event_form_spec.rb
+++ b/spec/forms/edit_event_form_spec.rb
@@ -53,6 +53,20 @@ RSpec.describe EditEventForm do
     end
   end
 
+  describe ".type_is_weekly_class?" do
+    it "is true if the event_type is weekly class" do
+      form = described_class.new(event_type: "weekly_class")
+
+      expect(form.type_is_weekly_class?).to be true
+    end
+
+    it "is false if the event is social dance" do
+      form = described_class.new(event_type: "social_dance")
+
+      expect(form.type_is_weekly_class?).to be false
+    end
+  end
+
   describe "#to_h" do
     it "returns the attributes as a symbol hash" do # rubocop:disable RSpec/ExampleLength
       form = described_class.new(

--- a/spec/system/editors_can_edit_events_spec.rb
+++ b/spec/system/editors_can_edit_events_spec.rb
@@ -180,6 +180,21 @@ RSpec.describe "Editors can edit events", :js do
     end
   end
 
+  context "when the event is a weekly class" do
+    it "doesn't allow the frequency to be edited" do
+      event = create(:class)
+      skip_login
+
+      visit edit_event_path(event)
+
+      aggregate_failures do
+        expect(page).to have_no_content("Monthly")
+        expect(page).to have_no_content("occasionally")
+        expect(page).to have_no_content("Upcoming dates")
+      end
+    end
+  end
+
   context "when the event has an old frequency" do
     it "shows a message" do
       event = create(:event, frequency: 4)


### PR DESCRIPTION
This isn't allowed, so we get an unhandled error if it happens. Prevent
it by not showing the monthly box if it's a persisted weekly class.

https://app.rollbar.com/a/swingoutlondon/fix/item/SOLDN/178
https://app.rollbar.com/a/swingoutlondon/fix/item/SOLDN/179