### PR TITLE
Filter HTTP logs

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,5 @@
 require "active_support/core_ext/integer/time"
+require "filtering_logger_formatter"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -71,6 +72,8 @@ Rails.application.configure do
     Bullet.rails_logger = true
     Bullet.add_footer = true
   end
+
+  config.log_formatter = FilteringLoggerFormatter.new(ActiveSupport::Logger::SimpleFormatter.new)
 
   config.hosts << ENV["HOST"] if ENV["HOST"]
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,5 @@
 require "active_support/core_ext/integer/time"
+require "filtering_logger_formatter"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -48,7 +49,7 @@ Rails.application.configure do
 
   # Log to STDOUT by default
   config.logger = ActiveSupport::Logger.new($stdout)
-    .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
+    .tap  { |logger| logger.formatter = FilteringLoggerFormatter.new(::Logger::Formatter.new) }
     .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
 
   # Prepend all log lines with the following tags.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,5 @@
 require "active_support/core_ext/integer/time"
+require "filtering_logger_formatter"
 
 # The test environment is used exclusively to run your application's
 # test suite. You never need to work with it otherwise. Remember that
@@ -51,6 +52,8 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  config.log_formatter = FilteringLoggerFormatter.new(ActiveSupport::Logger::SimpleFormatter.new)
 
   ENV["RACK_ENV"] = "test"
 end

--- a/lib/filtering_logger_formatter.rb
+++ b/lib/filtering_logger_formatter.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class FilteringLoggerFormatter
+  def initialize(base_formatter)
+    @base_formatter = base_formatter
+  end
+
+  def call(severity, time, progname, message)
+    @base_formatter.call(severity, time, progname, filter(message))
+  end
+
+  private
+
+  def filter(message)
+    message.gsub(/(Authorization: Bearer )\w+/, '\1[FILTERED]')
+  end
+end


### PR DESCRIPTION
The HTTP gem logs EVERYthing, including bearer tokens.

This is maybe not an actual problem since currently we have log level as
info in production in order to not max out the limits on papertrail. But
I don't want to change that later and unexpectedly leak data.

The solution is to create a log formatter which wraps the normal basic
formatter and sanitises the message.