### PR TITLE
Cache names from the Facebook graph API

### DIFF
--- a/spec/services/user_name_spec.rb
+++ b/spec/services/user_name_spec.rb
@@ -2,9 +2,17 @@
 
 require "spec_helper"
 require "app/services/user_name"
+require "active_support"
+require "active_support/cache"
+require "active_support/core_ext/integer/time"
 require "facebook_graph_api/http_client" # for the ResponseError class
 
 RSpec.describe UserName do
+  before do
+    cache = ActiveSupport::Cache::NullStore.new
+    stub_const("Rails", class_double("Rails", cache:))
+  end
+
   describe ".as_user" do
     it "builds an API client based on the user" do
       stub_const("Rollbar", double)


### PR DESCRIPTION
It's slow so we don't want to have to retrieve them every time we load
this page.