### PR TITLE
Fix: stop organiser link input from overflowing

### DIFF
--- a/app/assets/stylesheets/cms/_forms.scss
+++ b/app/assets/stylesheets/cms/_forms.scss
@@ -179,14 +179,20 @@ form.edit_venue {
   }
 }
 
+.organiser-link-input {
+  display:flex;
+  white-space: nowrap;
+  margin-bottom: 10px;
+}
+
 #organiser_link_url {
-  width: 40em;
+  width: 100%;
+  max-width: 660px;
   border: solid colours.$text-colour;
   border-right: none;
   border-radius: 5px 0 0 5px;
   background: inherit;
   padding: 5px;
-  margin-bottom: 10px;
 }
 
 .button-on-input {

--- a/app/views/events/_organiser_link.html.erb
+++ b/app/views/events/_organiser_link.html.erb
@@ -2,8 +2,10 @@
   <h3 class='form-section-title'><label for="organiser_link_url">Organiser edit link<label></h3>
   <turbo-frame id="organiser_link">
     <% if event.organiser_token %>
-      <input id="organiser_link_url" type="text" value="<%= edit_external_event_url(event.organiser_token) %>" data-organiser-link-target="source" readonly><!--
-   --><a href="#" class="button-on-input" data-action="organiser-link#copy">Copy</a>
+      <div class="organiser-link-input">
+        <input id="organiser_link_url" type="text" value="<%= edit_external_event_url(event.organiser_token) %>" data-organiser-link-target="source" readonly><!--
+     --><a href="#" class="button-on-input" data-action="organiser-link#copy">Copy</a>
+      </div>
     <% else %>
       <p>No organiser edit link exists for this event</p>
     <% end %>


### PR DESCRIPTION
This kind of breaks the layout on mobile