### PR TITLE
Protect against DNS rebinding attacks

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,6 +78,7 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # Enable DNS rebinding protection and other `Host` header attacks.
+  config.hosts << ENV["CANONICAL_HOST"] if ENV["CANONICAL_HOST"]
   # config.hosts = [
   #   "example.com",     # Allow requests from example.com
   #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`


### PR DESCRIPTION
Only allow traffic to the canonical host:

  https://prathamesh.tech/2019/09/02/dns-rebinding-attacks-protection-in-rails-6/
  https://guides.rubyonrails.org/configuring.html#actiondispatch-hostauthorization