### PR TITLE
Allow Facebook crawler to access login page

### DIFF
--- a/app/views/robots/index.text.erb
+++ b/app/views/robots/index.text.erb
@@ -14,6 +14,9 @@ Disallow: /map/classes/*
 User-agent: BLEXBot
 Disallow: /
 
+User-agent: facebookexternalhit
+Allow: /login
+
 <% if canonical_sitemap_url %>
-  Sitemap: <%= canonical_sitemap_url %>
+Sitemap: <%= canonical_sitemap_url %>
 <% end %>


### PR DESCRIPTION
This is to allow it to review our access and hopefully to stop us
getting randomly disabled all the time.

Also fix indentation of the sitemap statement