### PR TITLE
Add FB App ID to login page

### DIFF
--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,3 +1,9 @@
+<% content_for :head do %>
+  <% if Rails.configuration.x.facebook.app_id %>
+    <meta content="<%= Rails.configuration.x.facebook.app_id %>" property="fb:app_id"/>
+  <% end %>
+<% end %>
+
 <section class="login">
   <%= render "shared/flash" %>
 


### PR DESCRIPTION
This shows up as a required field:

  https://developers.facebook.com/tools/debug/?q=https%3A%2F%2Fwww.swingoutlondon.co.uk%2Flogin