### PR TITLE
Override Capybara selenium_chrome_headless driver

### DIFF
--- a/spec/support/system/drivers.rb
+++ b/spec/support/system/drivers.rb
@@ -1,5 +1,21 @@
 # frozen_string_literal: true
 
+# Override Capybara's selenium_chrome_headless driver to disable the chrome search engine selection modal
+# If Capybara adds the --disable-search-engine-choice-screen option as a default, we can delete this override.
+# This is mostly a copy of the definition from the Capybara source:
+Capybara.register_driver :selenium_chrome_headless do |app|
+  version = Capybara::Selenium::Driver.load_selenium
+  options_key = Capybara::Selenium::Driver::CAPS_VERSION.satisfied_by?(version) ? :capabilities : :options
+  browser_options = Selenium::WebDriver::Chrome::Options.new.tap do |opts|
+    opts.add_argument("--headless=new")
+    opts.add_argument("--disable-gpu") if Gem.win_platform?
+    opts.add_argument("--disable-site-isolation-trials")
+    opts.add_argument("--disable-search-engine-choice-screen")
+  end
+
+  Capybara::Selenium::Driver.new(app, **{ :browser => :chrome, options_key => browser_options })
+end
+
 module System
   module Drivers
     RSpec.configure do |config|


### PR DESCRIPTION
The most recent versions of Chrome prompt the user to select a search
engine when opening the browser for the first time. This happens even in
tests, causing tests to fail with errors like "window failed to close
after 20 seconds"

To to disable the chrome search engine selection modal we need to define
a new driver, since this option doesn't seem to be used in the
selenium_chrome_headless driver (which is defined by Capybara).

If Capybara adds the --disable-search-engine-choice-screen option as a
default, we can delete this override.