### PR TITLE
Validate Facebook ID when creating user

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -3,16 +3,16 @@
 module Admin
   class UsersController < BaseController
     def index
-      users = UsersListing.for_user(current_user).users
-      role_select_options = Role::ROLES.map { |role| [role.capitalize, role] }
-
-      render locals: { users:, new_user: Role.new, role_select_options: }
+      render locals: index_locals(new_user: Role.new)
     end
 
     def create
-      Role.create!(new_role_params)
-
-      redirect_to admin_users_path
+      role = Role.new(new_role_params)
+      if role.save
+        redirect_to admin_users_path
+      else
+        render :index, locals: index_locals(new_user: role)
+      end
     end
 
     def update
@@ -28,6 +28,13 @@ module Admin
     end
 
     private
+
+    def index_locals(new_user:)
+      users = UsersListing.for_user(current_user).users
+      role_select_options = Role::ROLES.map { |role| [role.capitalize, role] }
+
+      { users:, new_user:, role_select_options: }
+    end
 
     def new_role_params
       params.require(:role).permit(:facebook_ref, :role)

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -10,6 +10,7 @@ class Role < ApplicationRecord
     editor: EDITOR
   }
 
-  validates :facebook_ref, presence: true, uniqueness: true
+  validates :facebook_ref, presence: true, uniqueness: true, numeric_string: { allow_blank: true }
+
   validates :role, presence: true
 end

--- a/app/validators/numeric_string_validator.rb
+++ b/app/validators/numeric_string_validator.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class NumericStringValidator < ActiveModel::Validations::FormatValidator
+  def initialize(options)
+    options = options.dup
+    options[:with]    ||= /\A\d+\z/
+    options[:message] ||= "must contain only digits"
+    super
+  end
+end

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -2,6 +2,8 @@
   <h1>Users</h1>
 
   <%= form_with model: new_user, url: admin_users_path, class: "new-user-form" do |f| %>
+    <%= render "shared/error_messages", target: new_user %>
+
     <div class="form-group">
       <%= f.label :facebook_ref, "Facebook ID" %>
       <%= f.text_field :facebook_ref %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,9 @@ en:
     london: London
     bristol: Bristol
   activerecord:
+    attributes:
+      role:
+        facebook_ref: "Facebook ID"
     errors:
       models:
         event:

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -9,6 +9,9 @@ RSpec.describe Role do
 
     it { is_expected.to validate_uniqueness_of(:facebook_ref).case_insensitive }
     it { is_expected.to validate_presence_of(:facebook_ref) }
+    it { is_expected.to allow_value("123456789").for(:facebook_ref) }
+    it { is_expected.not_to allow_value("abc123").for(:facebook_ref) }
+    it { is_expected.not_to allow_value("12345abc").for(:facebook_ref) }
     it { is_expected.to validate_presence_of(:role) }
   end
 

--- a/spec/system/admins_can_manage_users_spec.rb
+++ b/spec/system/admins_can_manage_users_spec.rb
@@ -43,6 +43,29 @@ RSpec.describe "Admins can manage users" do
     end
   end
 
+  context "when the facebook ref is the wrong format" do
+    it "shows a validation error", :js, :vcr do
+      stub_facebook_config(app_secret!: "super-secret-secret")
+      stub_auth_hash(id: 98765987659876598)
+      create(:admin, facebook_ref: 98765987659876598)
+
+      visit "/admin/users"
+
+      VCR.use_cassette("fetch_facebook_names") do
+        click_on "Log in"
+      end
+
+      fill_in "Facebook ID", with: "dawn.hampton"
+      select "Editor", from: "Role"
+
+      VCR.use_cassette("fetch_facebook_names") do
+        click_on "Add user"
+
+        expect(page).to have_content("Facebook ID must contain only digits")
+      end
+    end
+  end
+
   it "removing a role", :js, :vcr do
     stub_facebook_config(app_secret!: "super-secret-secret")
     create(:editor, facebook_ref: 12345678901234567)


### PR DESCRIPTION
We had an issue on production where Chris added "meli.rousseau" as the
Facebook ID. This is obviously incorrect since IDs are numeric strings,
but worse, this record couldn't be deleted - maybe because of how the
dot in the name was interpreted (user couldn't be found).

This can all be avoided by adding some validation.