### PR TITLE
Don't include the Facebook test user in list

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,10 @@ FACEBOOK_SECRET=
 # FACEBOOK_APP_ID is the ID of the Facebook app used for logging in
 FACEBOOK_APP_ID=
 
+# FACEBOOK_TEST_USER_APP_ID is the ID of the Facebook test user,
+# which is used by Facebook to log in and verify that the site is legit
+FACEBOOK_TEST_USER_APP_ID=
+
 # Get this by signing up for a google cloud account:
 # https://developers.google.com/maps/documentation/javascript/tutorial
 GOOGLE_MAPS_JAVASCRIPT_API_KEY=

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -13,4 +13,10 @@ class Role < ApplicationRecord
   validates :facebook_ref, presence: true, uniqueness: true, numeric_string: { allow_blank: true }
 
   validates :role, presence: true
+
+  class << self
+    def real
+      where.not(facebook_ref: Rails.configuration.x.facebook.test_user_app_id)
+    end
+  end
 end

--- a/app/presenters/users_listing.rb
+++ b/app/presenters/users_listing.rb
@@ -3,7 +3,7 @@
 # Presenter for displaying a list of "Users" based on the {Role}s stored in the
 # database.
 class UsersListing
-  def initialize(current_user_id:, user_name_finder:, roles: Role.all)
+  def initialize(current_user_id:, user_name_finder:, roles: Role.real)
     @roles = roles
     @current_user_id = current_user_id
     @user_name_finder = user_name_finder

--- a/config/initializers/facebook.rb
+++ b/config/initializers/facebook.rb
@@ -4,4 +4,5 @@ Rails.application.configure do
   config.x.facebook.app_id = ENV.fetch("FACEBOOK_APP_ID", nil)
   config.x.facebook.app_secret = ENV.fetch("FACEBOOK_SECRET", nil)
   config.x.facebook.api_base = "https://graph.facebook.com/"
+  config.x.faceboook.test_user_app_id = ENV.fetch("FACEBOOK_TEST_USER_APP_ID", nil)
 end

--- a/spec/system/admins_can_manage_users_spec.rb
+++ b/spec/system/admins_can_manage_users_spec.rb
@@ -140,11 +140,11 @@ RSpec.describe "Admins can manage users" do
       expect(page).to have_content("Dawn Hampton (Admin)")
     end
 
-    within(user_row("Dawn Hampton")) do
-      click_on("Remove admin")
-    end
-
     VCR.use_cassette("fetch_facebook_names") do
+      within(user_row("Dawn Hampton")) do
+        click_on("Remove admin")
+      end
+
       within(user_row("Dawn Hampton")) do
         expect(page).to have_no_content("(Admin)")
         expect(page).to have_no_content("Remove admin")

--- a/spec/system/admins_can_manage_users_spec.rb
+++ b/spec/system/admins_can_manage_users_spec.rb
@@ -153,6 +153,18 @@ RSpec.describe "Admins can manage users" do
     end
   end
 
+  it "does not show the facebook test user", :vcr do
+    test_user_app_id = "12345678901234567"
+    stub_facebook_config(test_user_app_id:, app_secret!: "super-secret-secret")
+    create(:editor, facebook_ref: test_user_app_id)
+
+    VCR.use_cassette("fetch_facebook_names") do
+      skip_login("/admin/users", admin: true)
+    end
+
+    expect(page).to have_no_content(test_user_app_id)
+  end
+
   context "when logged in as a non-admin" do
     it "does not allow access" do
       skip_login(admin: false)


### PR DESCRIPTION
Facebook very annoyingly require us to keep a test user account that
they can log into to verify that the site is legit.

However, for reasons I don't understand, the Graph API calls to fetch
its username fail, leading to errors every time we load the page.

Also someone deleted it by accident since it looks like just junk.

The solution is to special-case it and remove it from the page
completely.