### PR TITLE
Fix clipboard specs

### DIFF
--- a/spec/system/editors_can_copy_organiser_link_spec.rb
+++ b/spec/system/editors_can_copy_organiser_link_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe "Editors can copy an organiser link" do
 
       click_on "Copy"
 
+      expect(page).to have_content("Copied")
       expect(clipboard_text).to eq(url)
 
       allow(SecureRandom).to receive(:hex).and_return("xyz789")
@@ -50,8 +51,9 @@ RSpec.describe "Editors can copy an organiser link" do
       url = URI.join(page.server_url, "/external_events/abc123/edit").to_s
       expect(page).to have_field("Organiser edit link", with: url)
       expect(page).to have_link("revoke this link")
-      expect(page).to have_link("Copy")
+      expect(page).to have_content("Copied")
       expect(clipboard_text).to eq(url)
+      expect(page).to have_link("Copy")
     end
   end
 


### PR DESCRIPTION
The issue here is that on fast hardware the spec evaluates before the
content has been copied to the clipboard.

We can fix this by waiting for the "Copied" text to show