### PR TITLE
Don't let occasional organisers set last date

### DIFF
--- a/app/assets/stylesheets/cms/_forms.scss
+++ b/app/assets/stylesheets/cms/_forms.scss
@@ -173,6 +173,10 @@ form.edit_venue {
   }
 }
 
+form.edit_event section {
+  max-width: 500px;
+}
+
 .lat-lng {
   .row {
     display: flex;

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -126,11 +126,15 @@
       </p>
       <%= reasonable_date_field f, :first_date %>
     </div>
-    <div class='form-group'>
-      <%= f.label :last_date %>
-      <p class='help'>The event will stop being included in the listings after this date</p>
-      <%= reasonable_date_field f, :last_date, allow_past: @form.persisted? %>
-    </div>
+    <section>
+      <h3 class="form-section-title">Is this event ending or taking a break?</h3>
+      <p class='help'>If not, then please leave this blank</p>
+      <div class='form-group'>
+        <%= f.label :last_date %>
+        <p class='help'>The event will stop being included in the listings after this date</p>
+        <%= reasonable_date_field f, :last_date, allow_past: @form.persisted? %>
+      </div>
+    </section>
 
   </section>
 

--- a/app/views/external_events/edit.html.erb
+++ b/app/views/external_events/edit.html.erb
@@ -44,11 +44,14 @@
     <%= f.text_field :cancellations %>
   </div>
 
-  <div class='form-group'>
-    <%= f.label :last_date %>
-    <p class='help'>The event will stop showing up on the site after this date</p>
-    <%= f.date_field :last_date, value: @form.last_date %>
-  </div>
+  <section>
+    <h3 class="form-section-title">Is this event ending or taking a break?</h3>
+    <div class='form-group'>
+      <%= f.label :last_date %>
+      <p class='help'>The event will stop showing up on the site after this date</p>
+      <%= f.date_field :last_date, value: @form.last_date %>
+    </div>
+  </section>
 
   <div class='form-group actions'>
     <%= f.submit 'Update', class: 'button' %>

--- a/app/views/external_events/edit.html.erb
+++ b/app/views/external_events/edit.html.erb
@@ -46,8 +46,8 @@
 
   <div class='form-group'>
     <%= f.label :last_date %>
+    <p class='help'>The event will stop showing up on the site after this date</p>
     <%= f.date_field :last_date, value: @form.last_date %>
-    <span class='help'>The event will stop showing up on the site after this date</span>
   </div>
 
   <div class='form-group actions'>

--- a/app/views/external_events/edit.html.erb
+++ b/app/views/external_events/edit.html.erb
@@ -44,14 +44,16 @@
     <%= f.text_field :cancellations %>
   </div>
 
-  <section>
-    <h3 class="form-section-title">Is this event ending or taking a break?</h3>
-    <div class='form-group'>
-      <%= f.label :last_date %>
-      <p class='help'>The event will stop showing up on the site after this date</p>
-      <%= f.date_field :last_date, value: @form.last_date %>
-    </div>
-  </section>
+  <% if @event.weekly? || (@event.infrequent? && @event.last_date.present?) %>
+    <section>
+      <h3 class="form-section-title">Is this event ending or taking a break?</h3>
+      <div class='form-group'>
+        <%= f.label :last_date %>
+        <p class='help'>The event will stop showing up on the site after this date</p>
+        <%= f.date_field :last_date, value: @form.last_date %>
+      </div>
+    </section>
+  <% end %>
 
   <div class='form-group actions'>
     <%= f.submit 'Update', class: 'button' %>

--- a/spec/system/organisers_can_edit_events_spec.rb
+++ b/spec/system/organisers_can_edit_events_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe "Organisers can edit events" do
       autocomplete_select "The 100 Club", from: "Venue"
       fill_in "Upcoming dates", with: "12/12/2012, 12/01/2013"
       fill_in "Cancelled dates", with: "12/12/2012"
-      fill_in "Last date", with: "12/01/2013"
       click_on "Update"
 
       expect(page).to have_content("Event was successfully updated")
@@ -40,7 +39,6 @@ RSpec.describe "Organisers can edit events" do
         expect(page).to have_field("Venue", with: "The 100 Club - central")
         expect(page).to have_field("Upcoming dates", with: "12/12/2012,12/01/2013")
         expect(page).to have_field("Cancelled dates", with: "12/12/2012")
-        expect(page).to have_field("Last date", with: "2013-01-12")
         expect(page).to have_content("Event was successfully updated")
       end
 
@@ -102,7 +100,6 @@ RSpec.describe "Organisers can edit events" do
       autocomplete_select "The 100 Club", from: "Venue"
       fill_in "Upcoming dates", with: "12/12/2012, 12/01/2013"
       fill_in "Cancelled dates", with: "12/12/2012"
-      fill_in "Last date", with: "12/01/2013"
 
       click_on "Cancel"
 
@@ -110,7 +107,31 @@ RSpec.describe "Organisers can edit events" do
         expect(page).to have_field("Venue", with: "The Bishopsgate Centre - Liverpool st")
         expect(page).to have_field("Upcoming dates", with: "01/02/2036")
         expect(page).to have_field("Cancelled dates", with: "")
-        expect(page).to have_field("Last date", with: "")
+      end
+    end
+
+    context "when the event is occasional but a last date has already been set" do
+      it "allows an organiser to remove it" do
+        create(
+          :social,
+          organiser_token: "abc123",
+          frequency: 0,
+          last_date: Date.new(2013, 1, 12),
+          event_instances: [build(:event_instance, date: "12/12/2012")]
+        )
+        travel_to("2013-01-01")
+
+        visit("/external_events/abc123/edit")
+
+        expect(page).to have_field("Last date", with: "2013-01-12")
+
+        fill_in "Last date", with: ""
+        click_on "Update"
+
+        aggregate_failures do
+          expect(page).to have_content("Event was successfully updated")
+          expect(page).to have_no_content("Last date")
+        end
       end
     end
 


### PR DESCRIPTION
I don't think there's any point? This date never gets used for occasional
events? It's legacy from when we used to check for whether an event was
"active" or not.