### PR TITLE
Fix: don't show frequency for weekly class on error

### DIFF
--- a/app/forms/create_event_form.rb
+++ b/app/forms/create_event_form.rb
@@ -68,6 +68,10 @@ class CreateEventForm
     !event_type.nil?
   end
 
+  def show_frequency?
+    type_is_social_dance?
+  end
+
   def to_h
     attributes.symbolize_keys.merge(
       url: strip_redundant_query_params(url),

--- a/app/forms/edit_event_form.rb
+++ b/app/forms/edit_event_form.rb
@@ -77,6 +77,10 @@ class EditEventForm
     !event_type.nil?
   end
 
+  def show_frequency?
+    type_is_social_dance?
+  end
+
   def to_h
     attributes.symbolize_keys.merge(
       url: strip_redundant_query_params(url),

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -86,7 +86,7 @@
 
   <section data-event-form-target="when" class="<%= 'hidden' unless @form.show_when? %>">
     <h3 class='form-section-title'>When?</h3>
-    <div class='form-group' data-event-form-target="frequency">
+    <div class='form-group <%= "hidden" unless @form.show_frequency? %>' data-event-form-target="frequency">
       <h4 class="form-group-title">Frequency</h4>
       <label>
         <%= f.radio_button(:frequency, 1, data: { action: "event-form#setWeekly", "event-form-target" => "frequencyWeekly" }) %>

--- a/spec/system/editors_can_create_events_spec.rb
+++ b/spec/system/editors_can_create_events_spec.rb
@@ -248,6 +248,7 @@ RSpec.describe "Editors can create events", :js do
 
       expect(page).to have_content("1 error prevented this record from being saved")
         .and have_content("Class organiser must be present for classes")
+      expect(page).to have_no_content("Monthly") # This radio button should be hidden
 
       autocomplete_select "Sunshine Swing", from: "Class organiser"
       click_on "Create"


### PR DESCRIPTION
1. Start a new event
2. Select Weekly class
3. click save (get a validation error)

At this point we were in a state we hadn't accounted for: the "When?"
section is shown, but not as a direct result of clicking an event type.

As a result we were showing both frequency options, allowing the user to
select "occasional" and result in an error.

We fix this by applying a hidden class to the frequency section based on
event type.