### PR TITLE
Fix: validate cancelled dates are before last date

### DIFF
--- a/app/validators/form/valid_event_with_last_date.rb
+++ b/app/validators/form/valid_event_with_last_date.rb
@@ -3,13 +3,15 @@
 module Form
   class ValidEventWithLastDate < ActiveModel::Validator
     def validate(event)
+      return if event.last_date.blank?
+
       cannot_have_dates_after_last_date(event)
+      cannot_have_cancellations_after_last_date(event)
     end
 
     private
 
     def cannot_have_dates_after_last_date(event)
-      return if event.last_date.blank?
       return if event.parsed_dates.empty?
       return unless event.parsed_dates.max > Date.parse(event.last_date)
 
@@ -17,6 +19,17 @@ module Form
         :dates,
         "can't include dates after the last date. " \
         "Change or remove the \"Last date\" or remove the dates which are later than this"
+      )
+    end
+
+    def cannot_have_cancellations_after_last_date(event)
+      return if event.parsed_cancellations.empty?
+      return unless event.parsed_cancellations.max > Date.parse(event.last_date)
+
+      event.errors.add(
+        :cancellations,
+        "can't include dates after the last date. " \
+        "Change or remove the \"Last date\" or remove the cancelled dates which are later than this"
       )
     end
   end

--- a/spec/support/shared_examples/events/form/validates_event_with_last_date.rb
+++ b/spec/support/shared_examples/events/form/validates_event_with_last_date.rb
@@ -25,4 +25,15 @@ RSpec.shared_examples "validates event with last date (form)" do |model_name|
       ]
     )
   end
+
+  it "is invalid if it's weekly with a cancellation past the last date" do
+    model = build(model_name, :weekly, cancellations: "02/11/2011,31/10/2011", last_date: "2011-11-01")
+    model.valid?
+    expect(model.errors.messages).to eq(
+      cancellations: [
+        "can't include dates after the last date. " \
+        "Change or remove the \"Last date\" or remove the cancelled dates which are later than this"
+      ]
+    )
+  end
 end

--- a/spec/system/organisers_can_edit_events_spec.rb
+++ b/spec/system/organisers_can_edit_events_spec.rb
@@ -171,6 +171,21 @@ RSpec.describe "Organisers can edit events" do
     end
   end
 
+  context "when the cancellation dates are past the last date [REGRESSION]" do
+    it "shows validation errors" do
+      create(:class, organiser_token: "abc123")
+
+      visit("/external_events/abc123/edit")
+
+      fill_in "Cancelled dates", with: "29/09/2025"
+      fill_in "Last date", with: "2025-09-27"
+      click_on "Update"
+
+      expect(page).to have_content("1 error prevented this record from being saved:")
+        .and have_content("Cancellations can't include dates after the last date")
+    end
+  end
+
   context "when the organiser token is incorrect" do
     it "renders a 404" do
       visit("/external_events/abc123/edit")


### PR DESCRIPTION
We didn't have form level validations for cancellation dates being after
the last_date, but we do have them on the model, so we've gotten some
exceptions on production

I guess this was missed because it only applies to weekly classes: for
socials we get an earlier error that the cancelled dates don't appear in
the list of dates