### PR TITLE
Show audit log timestamps in LDN time

### DIFF
--- a/app/views/admin/audit_logs/show.html.erb
+++ b/app/views/admin/audit_logs/show.html.erb
@@ -1,11 +1,12 @@
 <main class="page">
   <h1>Audit Log</h1>
+  <p><%= t("audit_log.timezone_note") %></p>
 
   <% @audits.each do |audit| %>
     <% editor = Editor.build(audit) %>
     <p>
       <span class="timestamp">
-        [<%= audit.created_at.to_fs(:db) %>]
+        [<%= l(audit.created_at, format: :iso_no_zone) %>]
       </span>
       <span class="editor" title="<%= editor.auth_id %>">
         <%= editor.name %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -67,6 +67,7 @@
 <% if current_user.admin? %>
   <section class="audit_logs">
     <h3>Activity</h3>
+    <p><%= t("audit_log.timezone_note") %></p>
 
     <% if @audits.none? %>
       (No audit log entries - probably this event pre-dates the audit log)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,6 +4,7 @@ en:
       default: "%d/%m/%Y %H:%M:%S"
       short: "%d %b %H:%M"
       long: "%B %d, %Y %H:%M"
+      iso_no_zone: "%Y-%m-%d %H:%M:%S"
   date:
     formats:
       default: "%d/%m/%Y" # 11/10/2015
@@ -65,6 +66,8 @@ en:
       event_type:
         social_dance: Social dance
         weekly_class: Weekly class
+  audit_log:
+    timezone_note: Entries are show in London time
 
   organiser_mailer:
     reminder_email:


### PR DESCRIPTION
db format sneakily converts everything to UTC.

I guess the proper way is to use localisation, so that's what we do
here.