### PR TITLE
Move venue name into info window header

### DIFF
--- a/app/assets/stylesheets/website/_map.scss
+++ b/app/assets/stylesheets/website/_map.scss
@@ -27,12 +27,12 @@ body.socials {
     color: inherit;
   }
 
-  .venue_info {
-    h3 {
-      font-size: 1.2em;
-    }
+  .venue-info-header {
+    font-size: 1.2em;
+  }
 
-    .adr {
+  .venue-info-body {
+    .address {
       font-style: italic;
       font-size: 0.9em;
       margin-top: 0.3em;

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -51,6 +51,7 @@ export default class extends Controller {
       lat: venue.position.lat,
       lng: venue.position.lng,
       title: venue.title,
+      url: venue.url,
       highlighted: venue.highlighted,
       content: venue.infoWindowContent
     }

--- a/app/javascript/maps/map.js
+++ b/app/javascript/maps/map.js
@@ -50,7 +50,7 @@ export class Map {
     this.#mapInstance.fitBounds(bounds, padding)
   }
 
-  async _createMarker({ position, title, highlighted, only, content }) {
+  async _createMarker({ position, title, url, highlighted, only, content }) {
     const marker = new this.AdvancedMarkerElement({
       position: position,
       title: title,
@@ -58,7 +58,7 @@ export class Map {
       ...(highlighted ? { content: this._highlightedPin() } : {})
     });
 
-    const infoWindow = new google.maps.InfoWindow({ content })
+    const infoWindow = new google.maps.InfoWindow({ content, headerContent: this._infoHeader(title, url) })
     const infoWindowOpenArgs = { markerCoordinates: position, marker, infoWindow }
 
     marker.addListener('click', () =>
@@ -70,6 +70,18 @@ export class Map {
     if (only || highlighted) {
       this._openInfoWindow(infoWindowOpenArgs)
     }
+  }
+
+  _infoHeader(title, url) {
+    const h3 = document.createElement("h3")
+    h3.className = "venue-info-header"
+
+    const link = document.createElement("a")
+    link.href = url
+    link.textContent = title
+
+    h3.appendChild(link)
+    return h3
   }
 
   _openInfoWindow({ markerCoordinates, marker, infoWindow }) {

--- a/app/models/maps/markers.rb
+++ b/app/models/maps/markers.rb
@@ -47,6 +47,7 @@ module Maps
       {
         id: venue.id,
         title: venue.name,
+        url: venue.website,
         position:,
         highlighted:,
         infoWindowContent: info_window_content(venue)

--- a/app/views/maps/_map_info_address.html.erb
+++ b/app/views/maps/_map_info_address.html.erb
@@ -1,8 +1,4 @@
-<div class="venue_info">
-  <h3>
-    <%= link_to venue.name, venue.url %>
-  </h3>
-
+<div class="venue-info-body">
   <div class="address">
     <% venue.address_lines.each do |address_line| %>
       <p>

--- a/app/views/maps/_map_info_address.html.erb
+++ b/app/views/maps/_map_info_address.html.erb
@@ -1,15 +1,15 @@
-<div class="venue_info vcard">
-  <h3 class="url fn">
+<div class="venue_info">
+  <h3>
     <%= link_to venue.name, venue.url %>
   </h3>
 
-  <div class="adr">
+  <div class="address">
     <% venue.address_lines.each do |address_line| %>
       <p>
         <%= address_line %>
       </p>
     <% end %>
-    <p class="postal-code">
+    <p>
       <%= venue.postcode %>
     </p>
   </div>

--- a/spec/system/users_can_see_a_map_spec.rb
+++ b/spec/system/users_can_see_a_map_spec.rb
@@ -67,7 +67,6 @@ RSpec.describe "Users can view a map of upcoming events" do
       info_window_string = markers.first.fetch("infoWindowContent")
       info_window = Capybara.string(info_window_string)
       aggregate_failures do
-        expect(info_window).to have_content("The Alhambra")
         expect(info_window).to have_content("17-19 Argyle St")
         expect(info_window).to have_content("WC1H 8EJ")
         expect(info_window).to have_content("Thursday 6th June:")
@@ -79,7 +78,6 @@ RSpec.describe "Users can view a map of upcoming events" do
       info_window_string = markers.last.fetch("infoWindowContent")
       info_window = Capybara.string(info_window_string)
       aggregate_failures do
-        expect(info_window).to have_content("The Boudoir Club")
         expect(info_window).to have_content("22 Night Street")
         expect(info_window).to have_content("ZZ2 2ZZ")
         expect(info_window).to have_content("Saturday 8th June:")
@@ -144,7 +142,6 @@ RSpec.describe "Users can view a map of upcoming events" do
       expect(markers.count).to eq 1
       info_window_string = markers.first.fetch("infoWindowContent")
       info_window = Capybara.string(info_window_string)
-      expect(info_window).to have_content("The Daylight Centre")
       expect(info_window).to have_content("9 Mornington Crescent")
       expect(info_window).to have_content("DA7 1GH")
       expect(info_window).to have_content("Wednesdays")


### PR DESCRIPTION
This is now a first-class thing, and the windows look a lot better with the
title in the header field.