### PR TITLE
Enforce ordering of displayed dates

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -147,7 +147,7 @@ class Event < ApplicationRecord # rubocop:disable Metrics/ClassLength
     return [] if weekly?
 
     Rails.cache.fetch(dates_cache_key) do
-      event_instances.order(date: :asc).map(&:date)
+      event_instances.order(date: :asc).pluck(:date)
     end
   end
 
@@ -157,11 +157,11 @@ class Event < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def cancellations
-    event_instances.cancelled.map(&:date)
+    event_instances.cancelled.order(date: :asc).pluck(:date)
   end
 
   def future_cancellations
-    event_instances.cancelled.where(date: Date.current..).map(&:date)
+    event_instances.cancelled.where(date: Date.current..).order(date: :asc).pluck(:date)
   end
 
   # COMPARISON METHODS #

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -57,7 +57,19 @@ RSpec.describe Event do
       recent_instance = build(:event_instance, date: date1, cancelled: true)
       event = create(:event, event_instances: [recent_instance, old_instance])
 
-      expect(event.cancellations).to eq([date1, date2])
+      expect(event.cancellations).to eq([date2, date1])
+    end
+  end
+
+  describe ".future_cancellations" do
+    it "returns an ordered list of future cancellations" do
+      date1 = 1.year.from_now.to_date
+      date2 = 2.days.from_now.to_date
+      later_instance = build(:event_instance, date: date1, cancelled: true)
+      sooner_instance = build(:event_instance, date: date2, cancelled: true)
+      event = create(:event, event_instances: [later_instance, sooner_instance])
+
+      expect(event.future_cancellations).to eq([date2, date1])
     end
   end
 


### PR DESCRIPTION
These were instead being shown in postgres retrieval order.

Also use pluck - this avoids initializing an activerecord object.